### PR TITLE
Stop the TXIndex goroutine before closing the chain DB

### DIFF
--- a/cmd/node.go
+++ b/cmd/node.go
@@ -187,11 +187,12 @@ func (node *Node) Start() {
 
 func (node *Node) Stop() {
 	node.Server.Stop()
-	node.chainDB.Close()
 
 	if node.TXIndex != nil {
 		node.TXIndex.Stop()
 	}
+
+	node.chainDB.Close()
 }
 
 func validateParams(params *lib.BitCloutParams) {


### PR DESCRIPTION
The TXIndex processor goroutine can crash on exit:

```
github.com/dgraph-io/badger/v3.(*memTable).IncrRef(0x0)
        /home/gfodor/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.2103.1/memtable.go:231 +0x19
github.com/dgraph-io/badger/v3.(*DB).getMemTables(0xc0c5044000)
        /home/gfodor/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.2103.1/db.go:696 +0x1cc
github.com/dgraph-io/badger/v3.(*DB).get(0xc0c5044000, {0xc36526d4a0, 0x29, 0x29})
        /home/gfodor/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.2103.1/db.go:730 +0x165
github.com/dgraph-io/badger/v3.(*Txn).Get(0xc365204480, {0xc36526d470, 0x21, 0x30})
        /home/gfodor/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.2103.1/txn.go:478 +0x4da
github.com/bitclout/core/lib.GetBlock.func1(0xc365204480)
        /home/gfodor/1729/bitclout/core/lib/db_utils.go:2405 +0x95
github.com/dgraph-io/badger/v3.(*DB).View(0xc0c5044000, 0xc00e0835b0)
        /home/gfodor/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.2103.1/txn.go:806 +0x162
github.com/bitclout/core/lib.GetBlock(0xc00892bd40, 0xc0c5044000)
        /home/gfodor/1729/bitclout/core/lib/db_utils.go:2404 +0xfc
github.com/bitclout/core/lib.(*TXIndex).Update(0xc003e04370)
        /home/gfodor/1729/bitclout/core/lib/txindex.go:374 +0xe56
github.com/bitclout/core/lib.(*TXIndex).Start.func1()
        /home/gfodor/1729/bitclout/core/lib/txindex.go:171 +0xc5
created by github.com/bitclout/core/lib.(*TXIndex).Start
        /home/gfodor/1729/bitclout/core/lib/txindex.go:160 +0xbe
```

This happens because the chain DB is being closed before the indexer is stopped.