### PR TITLE
[Postgres] Added String Trimmer & Terminators for mention notifications

### DIFF
--- a/lib/notifier.go
+++ b/lib/notifier.go
@@ -174,12 +174,14 @@ func (notifier *Notifier) Update() error {
 				// Process mentions
 				bodyObj := &DeSoBodySchema{}
 				if err := json.Unmarshal(meta.Body, &bodyObj); err == nil {
-					dollarTagsFound := mention.GetTagsAsUniqueStrings('$', string(bodyObj.Body))
-					atTagsFound := mention.GetTagsAsUniqueStrings('@', string(bodyObj.Body))
-
+					terminators := []rune(" ,.\n&*()-+~'\"[]{}")
+					dollarTagsFound := mention.GetTagsAsUniqueStrings('$', string(bodyObj.Body), terminators...)
+					atTagsFound := mention.GetTagsAsUniqueStrings('@', string(bodyObj.Body), terminators...)
+					
 					tagsFound := append(dollarTagsFound, atTagsFound...)
 					for _, tag := range tagsFound {
-						profileFound := DBGetProfileEntryForUsername(notifier.badger, []byte(strings.ToLower(tag)))
+
+						profileFound := DBGetProfileEntryForUsername(notifier.badger, []byte(strings.ToLower(strings.Trim(tag, ",.\n&*()-+~'\"[]{}!?^%#"))))
 						// Don't worry about tags that don't line up to a profile.
 						if profileFound == nil {
 							continue


### PR DESCRIPTION
# The Problem
When mentioning a user on Deso with punctuation or other characters directly beside the mention, the user will not receive their expected notification. For the future Postgres notifications DB, this is caused when [core/notifier.go](https://github.com/deso-protocol/core/blob/main/lib/notifier.go) attempts to search for the mentioned user in the database, but neglects to terminate the mention for special characters.

# The Solution
Fixing this bug (Again for the future PG-based node) is fairly self-explanatory:

First, we can pass a terminator to [gernest/mention#GetTagsAsUniqueStrings](https://github.com/gernest/mention/blob/d48aa4355f942e79e1a4ac2bd08c5c46371b78ca/mention.go#L66), which allows the package to terminate a mention when characters such as () are present. For example, a mention of `(@ASG)` would still be considered a mention by the package, providing back `ASG` in the returned array. 

Secondly, since only alphanumeric characters and hyphens are allowed in Deso usernames, we can trim the returned tags of other characters when we search for them in the user database. For example, if we provide `(@ASG!!!)`, the package will return `ASG!!!` -- not removing the punctuation. If we don't remove such punctuation manually though, the notification will never be added since the user `ASG!!!` can not  possibly exist, and we remove non-existent users:
```go
if profileFound == nil {
    continue
}
```

# Notes
While I did test this change numerously in a sandbox environment, further testing may be required. Since the Postgres, DB is not currently used for notifications, and the table remains empty (In fact, this file is not utilized by any part of the node currently), this change can not be tested in a production-accurate environment at this time. Additionally, this change will not fix this existing bug short term. While I did investigate the changes which would be required to fix the issue using the current notifications setup, I decided that it would be best to simply fix this for the future PG database as the current method utilizes `AffectedPublicKeys`, which is a way more complex ballgame when attempting to fix an issue such as the above.

# Samples
These playground screenshots demonstrate the need for both the terminator, **and** the trimmed string:

<img width="350" alt="Screen Shot 2021-10-20 at 9 36 52 PM" src="https://user-images.githubusercontent.com/47159695/138196235-d06b4947-8049-430a-ad52-df3d647de238.png">
<img width="350" alt="Screen Shot 2021-10-20 at 9 38 28 PM" src="https://user-images.githubusercontent.com/47159695/138196384-989b352d-d450-41bf-bb07-deb271bbf212.png">


