### PR TITLE
Allow pending NFT sales (FORKING CHANGE)

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -6820,9 +6820,13 @@ func (bav *UtxoView) _connectUpdateNFT(
 		return 0, 0, nil, RuleErrorCannotUpdateNonExistentNFT
 	}
 
-	// Verify the NFT is not a pending transfer.
-	if prevNFTEntry.IsPending {
-		return 0, 0, nil, RuleErrorCannotUpdatePendingNFTTransfer
+	// Prior to the "AllowPendingNFTSalesBlockHeight", one could not update (ie. put for sale)
+	// a pending NFT. At this block height, updating a transferred NFT also accepts it.
+	if blockHeight < AllowPendingNFTSalesBlockHeight {
+		// Verify the NFT is not a pending transfer.
+		if prevNFTEntry.IsPending {
+			return 0, 0, nil, RuleErrorCannotUpdatePendingNFTTransfer
+		}
 	}
 
 	// Get the postEntry so we can update the number of NFT copies for sale.
@@ -6886,6 +6890,7 @@ func (bav *UtxoView) _connectUpdateNFT(
 		NFTPostHash:       txMeta.NFTPostHash,
 		SerialNumber:      txMeta.SerialNumber,
 		IsForSale:         txMeta.IsForSale,
+		IsPending:         false, // Updating an NFT automatically accepts it.
 		MinBidAmountNanos: txMeta.MinBidAmountNanos,
 		UnlockableText:    prevNFTEntry.UnlockableText,
 		// Keep the last accepted bid amount nanos from the previous entry since this

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -123,6 +123,10 @@ var (
 	// transfer txns, NFT burn txns, and AuthorizeDerivedKey txns will be accepted.
 	// Triggers: 12PM PT on 9/15/2021
 	NFTTransferOrBurnAndDerivedKeysBlockHeight = uint32(60743)
+
+	// Defines the height at which NFTs that are a pending transfer can be resold.
+	// Triggers: TBD
+	AllowPendingNFTSalesBlockHeight = uint32(80000)
 )
 
 func (nt NetworkType) String() string {
@@ -488,11 +492,11 @@ var DeSoMainnetParams = DeSoParams{
 		StatusBitcoinHeaderValidated,
 	),
 
-	BitcoinExchangeFeeBasisPoints:   10,
-	BitcoinDoubleSpendWaitSeconds:   5.0,
-	DeSoNanosPurchasedAtGenesis: uint64(6000000000000000),
-	DefaultSocketPort:               uint16(17000),
-	DefaultJSONPort:                 uint16(17001),
+	BitcoinExchangeFeeBasisPoints: 10,
+	BitcoinDoubleSpendWaitSeconds: 5.0,
+	DeSoNanosPurchasedAtGenesis:   uint64(6000000000000000),
+	DefaultSocketPort:             uint16(17000),
+	DefaultJSONPort:               uint16(17001),
 
 	DialTimeout:               30 * time.Second,
 	VersionNegotiationTimeout: 30 * time.Second,
@@ -630,11 +634,11 @@ var DeSoTestnetParams = DeSoParams{
 	// ===================================================================================
 	// Testnet Bitcoin config
 	// ===================================================================================
-	BitcoinBtcdParams:               &chaincfg.TestNet3Params,
-	BitcoinBurnAddress:              "mhziDsPWSMwUqvZkVdKY92CjesziGP3wHL",
-	BitcoinExchangeFeeBasisPoints:   10,
-	BitcoinDoubleSpendWaitSeconds:   5.0,
-	DeSoNanosPurchasedAtGenesis: uint64(6000000000000000),
+	BitcoinBtcdParams:             &chaincfg.TestNet3Params,
+	BitcoinBurnAddress:            "mhziDsPWSMwUqvZkVdKY92CjesziGP3wHL",
+	BitcoinExchangeFeeBasisPoints: 10,
+	BitcoinDoubleSpendWaitSeconds: 5.0,
+	DeSoNanosPurchasedAtGenesis:   uint64(6000000000000000),
 
 	// See comment in mainnet config.
 	BitcoinStartBlockNode: NewBlockNode(


### PR DESCRIPTION
As it stands, users that want to put transferred NFTs up for sale must first "accept" the NFT transfer.  This is cumbersome and does not add any obvious utility. This PR removes that restriction, automatically accepting an NFT transfer when it is put up for sale.

In drafting this change, I took inventory of all NFT transactions and noted those that are affected by the "IsPending" status of an NFT.  This is the current state of NFT consensus:

Unaffected NFT Transaction:
  - CreateNFT
  - BurnNFT
  - NFTTransfer (one can already transfer a pending NFT)

Affected NFT Transactions:
  - NFTBid -> Can't bid on a pending NFT.
  - AcceptNFTBid -> Can't accept a bid on a pending NFT.
  - UpdateNFT -> You can't update an NFT that is a pending transfer.
  - AcceptNFTTransfer -> Sanity check's that an NFT is not for sale before accepting a transfer.  Therefore, if an NFT was for sale *and* pending, one could not accept it.  Since it is unreasonable to create a state where the user cannot accept a transfer, this must be avoided.

Given the current state of consensus, the best solution is to force a user to accept a transfer if they update an NFT.  This prevents us from being in a situation where an NFT is for sale and pending while keeping all other logic working as expected.