### PR TITLE
add constants for NotGraylisted and NotBlacklisted

### DIFF
--- a/lib/constants.go
+++ b/lib/constants.go
@@ -801,8 +801,10 @@ var (
 )
 
 var (
-	IsGraylisted  = []byte{1}
-	IsBlacklisted = []byte{1}
+	IsGraylisted   = []byte{1}
+	IsBlacklisted  = []byte{1}
+	NotGraylisted  = []byte{0}
+	NotBlacklisted = []byte{0}
 )
 
 // InitialGlobalParamsEntry to be used before ParamUpdater creates the first update.


### PR DESCRIPTION
This will allow nodes that connect to a remote global state to unblacklist and ungraylist users that were restricted on the remote global state to which they connected.