### PR TITLE
Fix bug and add check for mempool in test.

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -5608,7 +5608,7 @@ func (bav *UtxoView) _connectUpdateGlobalParams(
 	var prevForbiddenPubKeyEntry *ForbiddenPubKeyEntry
 	var forbiddenPubKey []byte
 	if _, exists := extraData[ForbiddenBlockSignaturePubKeyKey]; exists {
-		forbiddenPubKey := extraData[ForbiddenBlockSignaturePubKeyKey]
+		forbiddenPubKey = extraData[ForbiddenBlockSignaturePubKeyKey]
 
 		if len(forbiddenPubKey) != btcec.PubKeyBytesLenCompressed {
 			return 0, 0, nil, RuleErrorForbiddenPubKeyLength

--- a/lib/blockchain_test.go
+++ b/lib/blockchain_test.go
@@ -1553,6 +1553,10 @@ func TestForbiddenBlockSignaturePubKey(t *testing.T) {
 	require.NoError(err)
 	require.Equal(1, len(txDescsAdded))
 
+	// Make sure that the forbidden pub key made it into the mempool properly.
+	_, entryExists := mempool.universalUtxoView.ForbiddenPubKeyToForbiddenPubKeyEntry[MakePkMapKey(blockSignerPkBytes)]
+	require.True(entryExists)
+
 	// Mine the transaction.
 	forbiddenPubKeyBlock, err := miner.MineAndProcessSingleBlock(0 /*threadIndex*/, mempool)
 	require.NoError(err)


### PR DESCRIPTION
Currently, there is a bug in the "ForbiddenBlockSignaturePubKey" logic.  The bug incorrectly creates a locally scoped "forbiddenPubKey" variable within an if-statement such that the properly scoped forbiddenPubKey variable is never set.  This makes it so that the ForbiddenPubKeyEntry is incorrectly indexed in the mempool.  The transaction still functions properly once it is flushed to the database but if more than one pub key were forbidden at a time, unintended behavior would occur.  This PR fixes that bug and adds a mempool check to the test.   