### PR TITLE
Typo in Swap Identity Txt String

### DIFF
--- a/lib/network.go
+++ b/lib/network.go
@@ -265,7 +265,7 @@ const (
 	TxnStringFollow                       TxnString = "FOLLOW"
 	TxnStringLike                         TxnString = "LIKE"
 	TxnStringCreatorCoin                  TxnString = "CREATOR_COIN"
-	TxnStringSwapIdentity                 TxnString = "SWAP_IDENTIY"
+	TxnStringSwapIdentity                 TxnString = "SWAP_IDENTITY"
 	TxnStringUpdateGlobalParams           TxnString = "UPDATE_GLOBAL_PARAMS"
 	TxnStringCreatorCoinTransfer          TxnString = "CREATOR_COIN_TRANSFER"
 	TxnStringCreateNFT                    TxnString = "CREATE_NFT"


### PR DESCRIPTION
Note this invalid transaction type is now on chain - not sure whether that will cause issues syncing - my nodes seem to be in sync. 

See #136

@maebeam 