### PR TITLE
Fix swap identity txn string.

### DIFF
--- a/lib/network.go
+++ b/lib/network.go
@@ -265,7 +265,7 @@ const (
 	TxnStringFollow                       TxnString = "FOLLOW"
 	TxnStringLike                         TxnString = "LIKE"
 	TxnStringCreatorCoin                  TxnString = "CREATOR_COIN"
-	TxnStringSwapIdentity                 TxnString = "SWAP_IDENTIY"
+	TxnStringSwapIdentity                 TxnString = "SWAP_IDENTITY"
 	TxnStringUpdateGlobalParams           TxnString = "UPDATE_GLOBAL_PARAMS"
 	TxnStringCreatorCoinTransfer          TxnString = "CREATOR_COIN_TRANSFER"
 	TxnStringCreateNFT                    TxnString = "CREATE_NFT"


### PR DESCRIPTION
As pointed out by @starykolarz (https://github.com/deso-protocol/core/issues/136), a commit three weeks ago accidentally updated the value of TxnStringSwapIdentity.  This string is not depended upon in any core DeSo repositories.  It is used for displaying human-readable transaction types to users in the form or TxIndex metadata (https://github.com/deso-protocol/core/blob/b5e24e68c982d26e0dcae4267111abec8e12c0ec/lib/mempool.go#L1116).  Any time a system is built on top of DeSo, it should instead rely on the txn type integers here: https://github.com/deso-protocol/core/blob/b5e24e68c982d26e0dcae4267111abec8e12c0ec/lib/network.go#L227-L252.  These values are extensively tested and are more efficient than the equivalent string comparison.  

Thank you @starykolarz for the find!