### PR TITLE
Add NFTz Node

### DIFF
--- a/lib/nodes.go
+++ b/lib/nodes.go
@@ -6,6 +6,19 @@ type DeSoNode struct {
 	Owner string
 }
 
+//
+// This list of nodes is maintained by the core DeSo developer team.
+//
+// If you run a DeSo node that has been online for at least one month you may submit a pull request to add your
+// node to the list of nodes.
+//
+// When submitting a post, add the following to PostExtraData:
+//   "Node": "ID"
+//
+// If your node is in the list then other nodes will be able to know where users are posting and can include
+// a link to your node and give you free advertising.
+//
+
 var NODES = map[uint64]DeSoNode{
 	1: {
 		Name:  "DeSo",


### PR DESCRIPTION
Add NFTz Node. We started early October and have Minting and Post options. nftz.zone is our frontend. DeSo transactions are processed by node.nftz.zone or api.nftz.zone. Bumped to id 12 since I saw there is a pr for 11