### PR TITLE
Added additional nodes

### DIFF
--- a/lib/nodes.go
+++ b/lib/nodes.go
@@ -85,4 +85,34 @@ var NODES = map[uint64]DeSoNode{
 		URL:   "https://nftz.zone",
 		Owner: "mvanhalen",
 	},
+	13: {
+		Name:  "Cloutible",
+		URL:   "https://cloutible.club",
+		Owner: "DawaynePerza",
+	},
+	14: {
+		Name:  "Agbegbe",
+		URL:   "https://agbegbe.org",
+		Owner: "TheParkerazzi",
+	},
+	15: {
+		Name:  "CloutingAround",
+		URL:   "https://cloutingaround.dev",
+		Owner: "TheParkerazzi",
+	},
+	16: {
+		Name:  "MediaTech",
+		URL:   "https://deso.mediatech.ventures",
+		Owner: "paulobrien",
+	},
+	17: {
+		Name:  "Mousai",
+		URL:   "https://deso.mousai.stream",
+		Owner: "marlonjm2k",
+	},
+	18: {
+		Name:  "KoalaTBooks",
+		URL:   "https://koalatbooks.com",
+		Owner: "chriscelaya",
+	},
 }


### PR DESCRIPTION
Added Nodes 13 - 18 to the registry list. 

Each of these machines is owned and operated by SeismicCore, LLC on behalf of our clients listed in the "Owner" field therein. Each node meets all necessary listing criteria, and has been operating for at least 30 days.