### PR TITLE
Removed ineligible node

### DIFF
--- a/lib/nodes.go
+++ b/lib/nodes.go
@@ -25,11 +25,6 @@ type DeSoNode struct {
 //
 
 var NODES = map[uint64]DeSoNode{
-	1: {
-		Name:  "DeSo",
-		URL:   "https://node.deso.org",
-		Owner: "diamondhands",
-	},
 	2: {
 		Name:  "BitClout",
 		URL:   "https://bitclout.com",


### PR DESCRIPTION
Per the requirements outlined in [lib/nodes.go](https://github.com/deso-protocol/core/blob/main/lib/nodes.go), a validator must be active for at least 30 days (1 month) prior to being eligible for the centralized sources list. The requirements state the following:
> If you run a DeSo node that has been online for at least one month you may submit a pull request to add your node to the list of nodes.

The node located at [node.deso.org](https://node.deso.org) does not meet these requirements, as it has only been online since November 9th. Because of this, the node is ineligible to be listed here until December 9th.

This PR removes the ineligible node form the list to uphold the requirements established by the core team for this centralized list. Should the owner decides they want to re-list their node after December 9th, they should create a PR as outlined in the requirements quoted above. 
<hr>
The following sources demonstrate the ineligibility for this node:

<br>
<br>
<img width="500" src="https://user-images.githubusercontent.com/47159695/144063866-81da378e-3d22-404e-b66a-8516627c17e7.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/47159695/144062184-5403b0f1-960f-4b0c-8376-7442f8d2ab42.png">