### PR TITLE
Fix bug introduced by NFT splits

### DIFF
--- a/lib/block_view_nft.go
+++ b/lib/block_view_nft.go
@@ -1283,12 +1283,15 @@ func (bav *UtxoView) _helpConnectNFTSold(args HelpConnectNFTSoldStruct) (
 	}
 
 	nftPaymentUtxoKeys := []*UtxoKey{}
-	nextUtxoIndex := uint32(len(args.Txn.TxOutputs))
+	// This may start negative but that's OK because the first thing we do is increment it
+	// in createUTXO
+	nextUtxoIndex := len(args.Txn.TxOutputs) - 1
 	createUTXO := func(amountNanos uint64, publicKey []byte, utxoType UtxoType) (_err error) {
+		// nextUtxoIndex is guaranteed to be >= 0 afer this increment
 		nextUtxoIndex += 1
 		royaltyOutputKey := &UtxoKey{
 			TxID:  *args.TxHash,
-			Index: nextUtxoIndex,
+			Index: uint32(nextUtxoIndex),
 		}
 
 		utxoEntry := UtxoEntry{


### PR DESCRIPTION
What was happening?
* Before, the royalty UTXO indices would start at len(txn.TxOutputs), as they should.
* NFT splits introduced a bug where they start at len(txn.TxOutputs)+1
on accident.

This bug is virtually impossible to find unless you sync a chain from
scratch, which I did as a final test.

This is because txn assembly will
happily use the incremented UTXOs rather than the unincremented ones and
it won't actually break anything in a test environment as long as the
txn construction code is the same as the connect() code.