### PR TITLE
Update Postgres handling of DAO Coins and NFTs

### DIFF
--- a/lib/block_view_profile.go
+++ b/lib/block_view_profile.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/glog"
+	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
 	"reflect"
 	"sort"
@@ -451,6 +452,16 @@ func (bav *UtxoView) setProfileMappings(profile *PGProfile) (*ProfileEntry, *PKI
 	if profile.Empty() {
 		bav.ProfilePKIDToProfileEntry[*pkidEntry.PKID] = nil
 	} else {
+		var daoCoinsInCirculationNanos *uint256.Int
+		if profile.DAOCoinCoinsInCirculationNanos != "" {
+			var err error
+			daoCoinsInCirculationNanos, err = uint256.FromHex(profile.DAOCoinCoinsInCirculationNanos)
+			if err != nil {
+				daoCoinsInCirculationNanos = uint256.NewInt()
+			}
+		} else {
+			daoCoinsInCirculationNanos = uint256.NewInt()
+		}
 		profileEntry = &ProfileEntry{
 			PublicKey:   profile.PublicKey.ToBytes(),
 			Username:    []byte(profile.Username),
@@ -460,13 +471,13 @@ func (bav *UtxoView) setProfileMappings(profile *PGProfile) (*ProfileEntry, *PKI
 				CreatorBasisPoints:      profile.CreatorBasisPoints,
 				DeSoLockedNanos:         profile.DeSoLockedNanos,
 				NumberOfHolders:         profile.NumberOfHolders,
-				CoinsInCirculationNanos: profile.CoinsInCirculationNanos,
+				CoinsInCirculationNanos: *uint256.NewInt().SetUint64(profile.CoinsInCirculationNanos),
 				CoinWatermarkNanos:      profile.CoinWatermarkNanos,
 				MintingDisabled:         profile.MintingDisabled,
 			},
 			DAOCoinEntry: CoinEntry{
 				NumberOfHolders:           profile.DAOCoinNumberOfHolders,
-				CoinsInCirculationNanos:   profile.DAOCoinCoinsInCirculationNanos,
+				CoinsInCirculationNanos:   *daoCoinsInCirculationNanos,
 				MintingDisabled:           profile.DAOCoinMintingDisabled,
 				TransferRestrictionStatus: profile.DAOCoinTransferRestrictionStatus,
 			},

--- a/lib/postgres.go
+++ b/lib/postgres.go
@@ -604,10 +604,17 @@ type PGDAOCoinBalance struct {
 }
 
 func (balance *PGDAOCoinBalance) NewBalanceEntry() *BalanceEntry {
-	balanceNanos, err := uint256.FromHex(balance.BalanceNanos)
-	if err != nil {
-		return nil
+	var balanceNanos *uint256.Int
+	if balance.BalanceNanos == "" {
+		var err error
+		balanceNanos, err = uint256.FromHex(balance.BalanceNanos)
+		if err != nil {
+			balanceNanos = uint256.NewInt()
+		}
+	} else {
+		balanceNanos = uint256.NewInt()
 	}
+
 	return &BalanceEntry{
 		HODLerPKID:  balance.HolderPKID,
 		CreatorPKID: balance.CreatorPKID,

--- a/lib/postgres.go
+++ b/lib/postgres.go
@@ -436,7 +436,7 @@ type PGProfile struct {
 	CoinWatermarkNanos      uint64
 	MintingDisabled         bool
 	DAOCoinNumberOfHolders  uint64 `pg:"dao_coin_number_of_holders"`
-	DAOCoinCoinsInCirculationNanos   string                    `pg:"dao_coin_coins_in_circulation"`
+	DAOCoinCoinsInCirculationNanos   string                    `pg:"dao_coin_coins_in_circulation_nanos"`
 	DAOCoinMintingDisabled           bool                      `pg:"dao_coin_minting_disabled"`
 	DAOCoinTransferRestrictionStatus TransferRestrictionStatus `pg:"dao_coin_transfer_restriction_status"`
 }

--- a/lib/postgres.go
+++ b/lib/postgres.go
@@ -125,6 +125,8 @@ type PGTransaction struct {
 	MetadataAcceptNFTTransfer   *PGMetadataAcceptNFTTransfer   `pg:"rel:belongs-to,join_fk:transaction_hash"`
 	MetadataBurnNFT             *PGMetadataBurnNFT             `pg:"rel:belongs-to,join_fk:transaction_hash"`
 	MetadataDerivedKey          *PGMetadataDerivedKey          `pg:"rel:belongs-to,join_fk:transaction_hash"`
+	MetadataDAOCoin             *PGMetadataDAOCoin             `pg:"rel:belongs-to,join_fk:transaction_hash"`
+	MetadataDAOCoinTransfer     *PGMetadataDAOCoinTransfer     `pg:"rel:belongs-to,join_fk:transaction_hash"`
 }
 
 // PGTransactionOutput represents DeSoOutput, DeSoInput, and UtxoEntry
@@ -266,8 +268,8 @@ type PGMetadataDAOCoin struct {
 	TransactionHash           *BlockHash           `pg:",pk,type:bytea"`
 	ProfilePublicKey          []byte               `pg:",type:bytea"`
 	OperationType             DAOCoinOperationType `pg:",use_zero"`
-	CoinsToMintNanos          uint64               `pg:",use_zero"`
-	CoinsToBurnNanos          uint64               `pg:",use_zero"`
+	CoinsToMintNanos          string
+	CoinsToBurnNanos          string
 	TransferRestrictionStatus `pg:",use_zero"`
 }
 
@@ -277,7 +279,7 @@ type PGMetadataDAOCoinTransfer struct {
 
 	TransactionHash        *BlockHash `pg:",pk,type:bytea"`
 	ProfilePublicKey       []byte     `pg:",type:bytea"`
-	DAOCoinToTransferNanos uint64     `pg:"dao_coin_to_transfer_nanos,use_zero"`
+	DAOCoinToTransferNanos string     `pg:"dao_coin_to_transfer_nanos,use_zero"`
 	ReceiverPublicKey      []byte     `pg:",type:bytea"`
 }
 
@@ -429,15 +431,12 @@ type PGProfile struct {
 	NumberOfHolders    uint64
 	// FIXME: Postgres will break when values exceed uint64
 	// We don't use Postgres right now so going to plow ahead and set this as-is
-	// to fix compile errors.
-	CoinsInCirculationNanos uint256.Int
+	// to fix compile errors. CoinsInCirculationNanos will never exceed uint64
+	CoinsInCirculationNanos uint64
 	CoinWatermarkNanos      uint64
 	MintingDisabled         bool
 	DAOCoinNumberOfHolders  uint64 `pg:"dao_coin_number_of_holders"`
-	// FIXME: Postgres will break when values exceed uint64
-	// We don't use Postgres right now so going to plow ahead and set this as-is
-	// to fix compile errors.
-	DAOCoinCoinsInCirculationNanos   uint256.Int               `pg:"dao_coin_coins_in_circulation"`
+	DAOCoinCoinsInCirculationNanos   string                    `pg:"dao_coin_coins_in_circulation"`
 	DAOCoinMintingDisabled           bool                      `pg:"dao_coin_minting_disabled"`
 	DAOCoinTransferRestrictionStatus TransferRestrictionStatus `pg:"dao_coin_transfer_restriction_status"`
 }
@@ -449,28 +448,30 @@ func (profile *PGProfile) Empty() bool {
 type PGPost struct {
 	tableName struct{} `pg:"pg_posts"`
 
-	PostHash                  *BlockHash `pg:",pk,type:bytea"`
-	PosterPublicKey           []byte
-	ParentPostHash            *BlockHash `pg:",type:bytea"`
-	Body                      string
-	RepostedPostHash          *BlockHash `pg:",type:bytea"`
-	QuotedRepost              bool       `pg:",use_zero"`
-	Timestamp                 uint64     `pg:",use_zero"`
-	Hidden                    bool       `pg:",use_zero"`
-	LikeCount                 uint64     `pg:",use_zero"`
-	RepostCount               uint64     `pg:",use_zero"`
-	QuoteRepostCount          uint64     `pg:",use_zero"`
-	DiamondCount              uint64     `pg:",use_zero"`
-	CommentCount              uint64     `pg:",use_zero"`
-	Pinned                    bool       `pg:",use_zero"`
-	NFT                       bool       `pg:",use_zero"`
-	NumNFTCopies              uint64     `pg:",use_zero"`
-	NumNFTCopiesForSale       uint64     `pg:",use_zero"`
-	NumNFTCopiesBurned        uint64     `pg:",use_zero"`
-	Unlockable                bool       `pg:",use_zero"`
-	CreatorRoyaltyBasisPoints uint64     `pg:",use_zero"`
-	CoinRoyaltyBasisPoints    uint64     `pg:",use_zero"`
-	ExtraData                 map[string][]byte
+	PostHash                                    *BlockHash `pg:",pk,type:bytea"`
+	PosterPublicKey                             []byte
+	ParentPostHash                              *BlockHash `pg:",type:bytea"`
+	Body                                        string
+	RepostedPostHash                            *BlockHash        `pg:",type:bytea"`
+	QuotedRepost                                bool              `pg:",use_zero"`
+	Timestamp                                   uint64            `pg:",use_zero"`
+	Hidden                                      bool              `pg:",use_zero"`
+	LikeCount                                   uint64            `pg:",use_zero"`
+	RepostCount                                 uint64            `pg:",use_zero"`
+	QuoteRepostCount                            uint64            `pg:",use_zero"`
+	DiamondCount                                uint64            `pg:",use_zero"`
+	CommentCount                                uint64            `pg:",use_zero"`
+	Pinned                                      bool              `pg:",use_zero"`
+	NFT                                         bool              `pg:",use_zero"`
+	NumNFTCopies                                uint64            `pg:",use_zero"`
+	NumNFTCopiesForSale                         uint64            `pg:",use_zero"`
+	NumNFTCopiesBurned                          uint64            `pg:",use_zero"`
+	Unlockable                                  bool              `pg:",use_zero"`
+	CreatorRoyaltyBasisPoints                   uint64            `pg:",use_zero"`
+	CoinRoyaltyBasisPoints                      uint64            `pg:",use_zero"`
+	AdditionalNFTRoyaltiesToCoinsBasisPoints    map[string]uint64 `pg:"additional_nft_royalties_to_coins_basis_points"`
+	AdditionalNFTRoyaltiesToCreatorsBasisPoints map[string]uint64 `pg:"additional_nft_royalties_to_creators_basis_points"`
+	ExtraData                                   map[string][]byte
 }
 
 func (post *PGPost) NewPostEntry() *PostEntry {
@@ -496,6 +497,14 @@ func (post *PGPost) NewPostEntry() *PostEntry {
 		NFTRoyaltyToCoinBasisPoints:    post.CoinRoyaltyBasisPoints,
 		NFTRoyaltyToCreatorBasisPoints: post.CreatorRoyaltyBasisPoints,
 		PostExtraData:                  post.ExtraData,
+	}
+
+	for pkid, bp := range post.AdditionalNFTRoyaltiesToCoinsBasisPoints {
+		postEntry.AdditionalNFTRoyaltiesToCoinsBasisPoints[*NewPKID([]byte(pkid))] = bp
+	}
+
+	for pkid, bp := range post.AdditionalNFTRoyaltiesToCreatorsBasisPoints {
+		postEntry.AdditionalNFTRoyaltiesToCreatorsBasisPoints[*NewPKID([]byte(pkid))] = bp
 	}
 
 	if post.ParentPostHash != nil {
@@ -590,16 +599,19 @@ type PGDAOCoinBalance struct {
 
 	HolderPKID   *PKID `pg:",pk,type:bytea"`
 	CreatorPKID  *PKID `pg:",pk,type:bytea"`
-	BalanceNanos uint64
+	BalanceNanos string
 	HasPurchased bool
 }
 
 func (balance *PGDAOCoinBalance) NewBalanceEntry() *BalanceEntry {
+	balanceNanos, err := uint256.FromHex(balance.BalanceNanos)
+	if err != nil {
+		return nil
+	}
 	return &BalanceEntry{
 		HODLerPKID:  balance.HolderPKID,
 		CreatorPKID: balance.CreatorPKID,
-		// FIXME: This will break if the value exceeds uint256
-		BalanceNanos: *uint256.NewInt().SetUint64(balance.BalanceNanos),
+		BalanceNanos: *balanceNanos,
 		HasPurchased: balance.HasPurchased,
 	}
 }
@@ -658,6 +670,8 @@ type PGNFT struct {
 	UnlockableText             string
 	LastAcceptedBidAmountNanos uint64 `pg:",use_zero"`
 	IsPending                  bool   `pg:",use_zero"`
+	IsBuyNow                   bool   `pg:",use_zero"`
+	BuyNowPriceNanos           uint64 `pg:",use_zero"`
 }
 
 func (nft *PGNFT) NewNFTEntry() *NFTEntry {
@@ -671,6 +685,8 @@ func (nft *PGNFT) NewNFTEntry() *NFTEntry {
 		UnlockableText:             []byte(nft.UnlockableText),
 		LastAcceptedBidAmountNanos: nft.LastAcceptedBidAmountNanos,
 		IsPending:                  nft.IsPending,
+		IsBuyNow:                   nft.IsBuyNow,
+		BuyNowPriceNanos:           nft.BuyNowPriceNanos,
 	}
 }
 
@@ -845,6 +861,8 @@ func (postgres *Postgres) InsertTransactionsTx(tx *pg.Tx, desoTxns []*MsgDeSoTxn
 	var metadataAcceptNFTTransfer []*PGMetadataAcceptNFTTransfer
 	var metadataBurnNFT []*PGMetadataBurnNFT
 	var metadataDerivedKey []*PGMetadataDerivedKey
+	var metadataDAOCoin []*PGMetadataDAOCoin
+	var metadataDAOCoinTransfer []*PGMetadataDAOCoinTransfer
 
 	blockHash := blockNode.Hash
 
@@ -1063,6 +1081,24 @@ func (postgres *Postgres) InsertTransactionsTx(tx *pg.Tx, desoTxns []*MsgDeSoTxn
 				OperationType:    txMeta.OperationType,
 				AccessSignature:  txMeta.AccessSignature,
 			})
+		} else if txn.TxnMeta.GetTxnType() == TxnTypeDAOCoin {
+			txMeta := txn.TxnMeta.(*DAOCoinMetadata)
+			metadataDAOCoin = append(metadataDAOCoin, &PGMetadataDAOCoin{
+				TransactionHash:           txnHash,
+				ProfilePublicKey:          txMeta.ProfilePublicKey,
+				OperationType:             txMeta.OperationType,
+				CoinsToMintNanos:          txMeta.CoinsToMintNanos.Hex(),
+				CoinsToBurnNanos:          txMeta.CoinsToBurnNanos.Hex(),
+				TransferRestrictionStatus: txMeta.TransferRestrictionStatus,
+			})
+		} else if txn.TxnMeta.GetTxnType() == TxnTypeDAOCoinTransfer {
+			txMeta := txn.TxnMeta.(*DAOCoinTransferMetadata)
+			metadataDAOCoinTransfer = append(metadataDAOCoinTransfer, &PGMetadataDAOCoinTransfer{
+				TransactionHash:        txnHash,
+				ProfilePublicKey:       txMeta.ProfilePublicKey,
+				DAOCoinToTransferNanos: txMeta.DAOCoinToTransferNanos.Hex(),
+				ReceiverPublicKey:      txMeta.ReceiverPublicKey,
+			})
 		} else {
 			return fmt.Errorf("InsertTransactionTx: Unimplemented txn type %v", txn.TxnMeta.GetTxnType().String())
 		}
@@ -1208,6 +1244,18 @@ func (postgres *Postgres) InsertTransactionsTx(tx *pg.Tx, desoTxns []*MsgDeSoTxn
 		}
 	}
 
+	if len(metadataDAOCoin) > 0 {
+		if _, err := tx.Model(&metadataDAOCoin).Returning("NULL").Insert(); err != nil {
+			return err
+		}
+	}
+
+	if len(metadataDAOCoinTransfer) > 0 {
+		if _, err := tx.Model(&metadataDAOCoinTransfer).Returning("NULL").Insert(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -1328,9 +1376,9 @@ func (postgres *Postgres) flushProfiles(tx *pg.Tx, view *UtxoView) error {
 			profile.CreatorBasisPoints = profileEntry.CreatorCoinEntry.CreatorBasisPoints
 			profile.DeSoLockedNanos = profileEntry.CreatorCoinEntry.DeSoLockedNanos
 			profile.NumberOfHolders = profileEntry.CreatorCoinEntry.NumberOfHolders
-			profile.CoinsInCirculationNanos = profileEntry.CreatorCoinEntry.CoinsInCirculationNanos
+			profile.CoinsInCirculationNanos = profileEntry.CreatorCoinEntry.CoinsInCirculationNanos.Uint64()
 			profile.CoinWatermarkNanos = profileEntry.CreatorCoinEntry.CoinWatermarkNanos
-			profile.DAOCoinCoinsInCirculationNanos = profileEntry.DAOCoinEntry.CoinsInCirculationNanos
+			profile.DAOCoinCoinsInCirculationNanos = profileEntry.DAOCoinEntry.CoinsInCirculationNanos.Hex()
 			profile.DAOCoinMintingDisabled = profileEntry.DAOCoinEntry.MintingDisabled
 			profile.DAOCoinNumberOfHolders = profileEntry.DAOCoinEntry.NumberOfHolders
 			profile.DAOCoinTransferRestrictionStatus = profileEntry.DAOCoinEntry.TransferRestrictionStatus
@@ -1394,6 +1442,18 @@ func (postgres *Postgres) flushPosts(tx *pg.Tx, view *UtxoView) error {
 
 		if len(postEntry.ParentStakeID) > 0 {
 			post.ParentPostHash = NewBlockHash(postEntry.ParentStakeID)
+		}
+
+		if len(postEntry.AdditionalNFTRoyaltiesToCoinsBasisPoints) > 0 {
+			for pkid, bps := range postEntry.AdditionalNFTRoyaltiesToCoinsBasisPoints {
+				post.AdditionalNFTRoyaltiesToCoinsBasisPoints[pkid.ToString()] = bps
+			}
+		}
+
+		if len(postEntry.AdditionalNFTRoyaltiesToCreatorsBasisPoints) > 0 {
+			for pkid, bps := range postEntry.AdditionalNFTRoyaltiesToCreatorsBasisPoints {
+				post.AdditionalNFTRoyaltiesToCreatorsBasisPoints[pkid.ToString()] = bps
+			}
 		}
 
 		if postEntry.isDeleted {
@@ -1609,8 +1669,7 @@ func (postgres *Postgres) flushDAOCoinBalances(tx *pg.Tx, view *UtxoView) error 
 		balance := &PGDAOCoinBalance{
 			HolderPKID:  balanceEntry.HODLerPKID,
 			CreatorPKID: balanceEntry.CreatorPKID,
-			// FIXME: This will break if the value exceeds uint256
-			BalanceNanos: balanceEntry.BalanceNanos.Uint64(),
+			BalanceNanos: balanceEntry.BalanceNanos.Hex(),
 			HasPurchased: balanceEntry.HasPurchased,
 		}
 
@@ -1708,6 +1767,8 @@ func (postgres *Postgres) flushNFTs(tx *pg.Tx, view *UtxoView) error {
 			UnlockableText:             string(nftEntry.UnlockableText),
 			LastAcceptedBidAmountNanos: nftEntry.LastAcceptedBidAmountNanos,
 			IsPending:                  nftEntry.IsPending,
+			IsBuyNow:                   nftEntry.IsBuyNow,
+			BuyNowPriceNanos:           nftEntry.BuyNowPriceNanos,
 		}
 
 		if nftEntry.isDeleted {

--- a/lib/types.go
+++ b/lib/types.go
@@ -25,6 +25,10 @@ func (pkid *PKID) ToBytes() []byte {
 	return pkid[:]
 }
 
+func (pkid *PKID) ToString() string {
+	return string(pkid.ToBytes())
+}
+
 func (pkid *PKID) NewPKID() *PKID {
 	newPkid := &PKID{}
 	copy(newPkid[:], pkid[:])

--- a/migrate/20210623152412_create_tables.go
+++ b/migrate/20210623152412_create_tables.go
@@ -298,7 +298,7 @@ func init() {
 				description                TEXT,
 				profile_pic                BYTEA,
 				creator_basis_points       BIGINT,
-				de_so_locked_nanos     BIGINT,
+				de_so_locked_nanos         BIGINT,
 				number_of_holders          BIGINT,
 				coins_in_circulation_nanos BIGINT,
 				coin_watermark_nanos       BIGINT

--- a/migrate/20220106162320_create_dao_coin_tables.go
+++ b/migrate/20220106162320_create_dao_coin_tables.go
@@ -55,6 +55,9 @@ func init() {
 				ADD COLUMN dao_coin_minting_disabled            BOOL,
 				ADD COLUMN dao_coin_transfer_restriction_status SMALLINT;
 			`)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	}

--- a/migrate/20220106162320_create_dao_coin_tables.go
+++ b/migrate/20220106162320_create_dao_coin_tables.go
@@ -79,5 +79,5 @@ func init() {
 
 	opts := migrations.MigrationOptions{}
 
-	migrations.Register("20210623152412_create_tables", up, down, opts)
+	migrations.Register("20220106162320_create_dao_coin_tables", up, down, opts)
 }

--- a/migrate/20220118103134_update_buy_now_nft_splits_and_fix_dao_types.go
+++ b/migrate/20220118103134_update_buy_now_nft_splits_and_fix_dao_types.go
@@ -1,0 +1,89 @@
+package migrate
+
+import (
+	"github.com/go-pg/pg/v10/orm"
+	migrations "github.com/robinjoseph08/go-pg-migrations/v3"
+)
+
+func init() {
+	up := func(db orm.DB) error {
+
+		_, err := db.Exec(`
+			ALTER TABLE pg_profiles
+				ALTER COLUMN dao_coin_coins_in_circulation_nanos TYPE TEXT USING '0x' || to_hex(dao_coin_coins_in_circulation_nanos);
+			`)
+		if err != nil {
+			return err
+		}
+
+		_, err = db.Exec(`
+			ALTER TABLE pg_metadata_dao_coins
+				ALTER COLUMN coins_to_mint_nanos TYPE TEXT USING '0x' || to_hex(coins_to_mint_nanos),
+				ALTER COLUMN coins_to_burn_nanos TYPE TEXT USING '0x' || to_hex(coins_to_burn_nanos) ;
+			`)
+		if err != nil {
+			return err
+		}
+
+		_, err = db.Exec(`
+			ALTER TABLE pg_metadata_dao_coin_transfers
+				ALTER COLUMN dao_coin_to_transfer_nanos TYPE TEXT USING '0x' || to_hex(dao_coin_to_transfer_nanos);
+			`)
+		if err != nil {
+			return err
+		}
+
+		_, err = db.Exec(`
+			ALTER TABLE pg_dao_coin_balances
+				ALTER COLUMN balance_nanos TYPE TEXT USING '0x' || to_hex(balance_nanos);
+			`)
+		if err != nil {
+			return err
+		}
+
+		_, err = db.Exec(`
+			ALTER TABLE pg_posts
+				ADD COLUMN additional_nft_royalties_to_coins_basis_points    JSONB,
+				ADD COLUMN additional_nft_royalties_to_creators_basis_points JSONB;
+			`)
+		if err != nil {
+			return err
+		}
+
+		_, err = db.Exec(`
+			ALTER TABLE pg_nfts
+				ADD COLUMN is_buy_now BOOL,
+				ADD COLUMN buy_now_price_nanos BIGINT; 
+			`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	down := func(db orm.DB) error {
+		_, err := db.Exec(`
+			ALTER TABLE pg_nfts
+				DROP COLUMN additional_nft_royalties_to_coins_basis_points,
+				DROP COLUMN additional_nft_royalties_to_creators_basis_points; 
+			ALTER TABLE pg_posts
+				DROP COLUMN is_buy_now,
+				DROP COLUMN buy_now_price_nanos;
+			ALTER TABLE pg_dao_coin_balances
+				ALTER COLUMN balance_nanos TYPE BIGINT USING lpad(balance_nanos, 16, '0')::bit(64)::bigint;
+			ALTER TABLE pg_metadata_dao_coin_transfers
+				ALTER COLUMN dao_coin_to_transfer_nanos TYPE BIGINT USING lpad(dao_coin_to_transfer_nanos, 16, '0')::bit(64)::bigint;
+			ALTER TABLE pg_metadata_dao_coins
+				ALTER COLUMN coins_to_mint_nanos TYPE BIGINT USING lpad(coins_to_mint_nanos, 16, '0')::bit(64)::bigint,
+				ALTER COLUMN coins_to_burn_nanos TYPE BIGINT USING lpad(coins_to_burn_nanos, 16, '0')::bit(64)::bigint;
+			ALTER TABLE pg_profiles
+				ALTER COLUMN dao_coin_coins_in_circulation_nanos TYPE BIGINT USING lpad(dao_coin_coins_in_circulation_nanos, 16, '0')::bit(64)::bigint; 
+		`)
+		return err
+	}
+
+	opts := migrations.MigrationOptions{}
+
+	migrations.Register("20210623152412_create_tables", up, down, opts)
+}

--- a/migrate/20220118103134_update_buy_now_nft_splits_and_fix_dao_types.go
+++ b/migrate/20220118103134_update_buy_now_nft_splits_and_fix_dao_types.go
@@ -85,5 +85,5 @@ func init() {
 
 	opts := migrations.MigrationOptions{}
 
-	migrations.Register("20210623152412_create_tables", up, down, opts)
+	migrations.Register("20220118103134_update_buy_now_nft_splits_and_fix_dao_types", up, down, opts)
 }


### PR DESCRIPTION
- use TEXT fields to store uint256 values
- add FK from dao coin / dao coin transfers to txn hash
- catch error in old migration and fix alignment
- add PKID to string method so we can easily convert a PKID to a string in order to store the additional royalty maps
- store additional royalty maps on posts in pg
- store IsBuyNow and BuyNowPriceNanos on NFTs in pg
- Fix registration of create dao coin tables migration