### PR TITLE
Allow 0 for transfer_restriction_status

### DIFF
--- a/migrate/20220106162320_create_dao_coin_tables.go
+++ b/migrate/20220106162320_create_dao_coin_tables.go
@@ -15,7 +15,7 @@ func init() {
 				operation_type              SMALLINT NOT NULL,
 				coins_to_mint_nanos         BIGINT NOT NULL,
 				coins_to_burn_nanos         BIGINT NOT NULL,
-				transfer_restriction_status SMALLINT NOT NULL
+				transfer_restriction_status SMALLINT
 			);
 		`)
 		if err != nil {


### PR DESCRIPTION
Sync fails on this as unrestricted is 0, but migration set field to not allow null.

Re: #198 