### PR TITLE
Add a SQL adapter for BlockHash that makes it work with bun

### DIFF
--- a/lib/types.go
+++ b/lib/types.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"github.com/btcsuite/btcd/btcec"
 )
@@ -100,4 +102,29 @@ func (bh *BlockHash) NewBlockHash() *BlockHash {
 	newBlockhash := &BlockHash{}
 	copy(newBlockhash[:], bh[:])
 	return newBlockhash
+}
+
+var _ sql.Scanner = (*BlockHash)(nil)
+
+// Scan scans the time parsing it if necessary using timeFormat.
+func (bb *BlockHash) Scan(src interface{}) (err error) {
+	switch src := src.(type) {
+	case []byte:
+		copy(bb[:], src)
+		return err
+	case nil:
+		return nil
+	default:
+		return fmt.Errorf("unsupported data type: %T", src)
+	}
+}
+
+var _ driver.Valuer = (*BlockHash)(nil)
+
+// Scan scans the time parsing it if necessary using timeFormat.
+func (bb *BlockHash) Value() (driver.Value, error) {
+	if bb == nil {
+		bb = &BlockHash{}
+	}
+	return bb[:], nil
 }


### PR DESCRIPTION
This will allow us to upgrade to Postgres v14 bu using the bun library
rather than the super old go-pg library, which is still stuck at v10