### PR TITLE
[fix] Disable possibility to transfer zero dao coins

### DIFF
--- a/lib/block_view_balance_entry.go
+++ b/lib/block_view_balance_entry.go
@@ -334,7 +334,11 @@ func (bav *UtxoView) HelpConnectCoinTransfer(
 	// For CreatorCoins, we must check that the amount of creator coin being
 	// transferred is not less than the min threshold. For DAO coins, this constraint
 	// doesn't matter because there is no bonding curve.
-	if !isDAOCoin {
+	if isDAOCoin {
+		if coinToTransferNanos.IsZero() && blockHeight > bav.Params.ForkHeights.DAOCoinZeroTransferFixHeight {
+			return 0, 0, nil, RuleErrorDAOCoinTransferMustTransferNonZero
+		}
+	} else {
 		// CreatorCoins can't exceed a uint64
 		if coinToTransferNanos.Uint64() < bav.Params.CreatorCoinAutoSellThresholdNanos {
 			return 0, 0, nil, RuleErrorCreatorCoinTransferMustBeGreaterThanMinThreshold

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -170,6 +170,9 @@ type ForkHeights struct {
 	// DAOCoinBlockHeight defines the height at which DAO Coin and DAO Coin Transfer
 	// transactions will be accepted.
 	DAOCoinBlockHeight uint32
+
+	// Till this block we could send zero coins in dao transfer
+	DAOCoinZeroTransferFixHeight uint32
 }
 
 // DeSoParams defines the full list of possible parameters for the
@@ -398,6 +401,7 @@ func (params *DeSoParams) EnableRegtest() {
 		DeSoV3MessagesBlockHeight:                            uint32(0),
 		BuyNowAndNFTSplitsBlockHeight:                        uint32(0),
 		DAOCoinBlockHeight:                                   uint32(0),
+		DAOCoinZeroTransferFixHeight:                         uint32(0),
 	}
 }
 
@@ -640,6 +644,8 @@ var DeSoMainnetParams = DeSoParams{
 		DeSoV3MessagesBlockHeight:                            uint32(98474),
 		BuyNowAndNFTSplitsBlockHeight:                        uint32(98474),
 		DAOCoinBlockHeight:                                   uint32(98474),
+		// TODO: set height
+		DAOCoinZeroTransferFixHeight:                         uint32(0),
 	},
 }
 
@@ -825,6 +831,8 @@ var DeSoTestnetParams = DeSoParams{
 		DeSoV3MessagesBlockHeight:                            uint32(97322),
 		BuyNowAndNFTSplitsBlockHeight:                        uint32(97322),
 		DAOCoinBlockHeight:                                   uint32(97322),
+		// TODO: set height
+		DAOCoinZeroTransferFixHeight:                         uint32(0),
 	},
 }
 

--- a/lib/errors.go
+++ b/lib/errors.go
@@ -239,6 +239,7 @@ const (
 	RuleErrorDAOCoinCannotDisableMintingIfAlreadyDisabled RuleError = "RuleErrorDAOCoinCannotDisableMintingIfAlreadyDisabled"
 	RuleErrorDAOCoinCannotMintIfMintingIsDisabled         RuleError = "RuleErrorDAOCoinCannotMintIfMintingIsDisabled"
 	RuleErrorOnlyProfileOwnerCanDisableMintingDAOCoin     RuleError = "RuleErrorOnlyProfileOwnerCanDisableMintingDAOCoin"
+	RuleErrorDAOCoinTransferMustTransferNonZero           RuleError = "RuleErrorDAOCoinTransferMustTransferNonZero"
 	RuleErrorDAOCoinTransferProfileOwnerOnlyViolation     RuleError = "RuleErrorDAOCoinTransferProfileOwnerOnlyViolation"
 	RuleErrorDAOCoinTransferDAOMemberOnlyViolation        RuleError = "RuleErrorDAOCoinTransferDAOMemberOnlyViolation"
 


### PR DESCRIPTION
This transaction sent zero dao coins – 3JuEUJQUPTYk4zRBQ9v7aRfYcs1dj8Sg7TUkdAuV1tyopd6ezn1SCX

And looks like its useless action at all and should be forbidden.

This fix disables zero dao coin transfers and throws out error on connect.