### PR TITLE
SOFT FORK: Today, Deso joins the decentralized movement

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -144,22 +144,6 @@ func SetupRunFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("block-producer-seed", "",
 		"When set, all blocks produced by the block producer will be signed by this "+
 			"seed.")
-	cmd.PersistentFlags().StringSlice("trusted-block-producer-public-keys", []string{
-		"BC1YLgS1zDJQqywFpsty4fFheUrZxVQNKEsrttppvUESFZCq6Nfoypm",
-		"BC1YLh768bVj2R3QpSiduxcvn7ipxF3L3XHsabZYtCGtsinUnNrZvNN",
-		"BC1YLgsiUgM1Vr35YwbkSfZB3NC9tyrMXBPuJ2SEBf8naDf6PRpNit9",
-		"BC1YLgW5jWudzSUvrvNkD4GReN3kvGvsTuqLLttKfsCbXb7vLSCjwTk",
-		"BC1YLi8X7U9DZc2UqPE4s5PjrNJJUa6PKygD7VF4u8vy96srm18YvEX",
-	},
-		"When set, this node will only accept new blocks that are signed by the trusted block "+
-			"producers. This setting, is pretty novel. It allows a network of full nodes who "+
-			"trust each other to create their own network that can't be easily taken over by a 51% "+
-			"attack. In some sense, it uses trust in order to lower the amount of work needed to "+
-			"protect the network, making it highly eco-friendly. Then, if full nodes ever want to "+
-			"allow open mining, all they need to do is unset these public keys (or one of the owners "+
-			"of the public keys can release her key material, pulling a metaphorical 'ripcord'). "+
-			"Importantly, until this point, the network will be completely protected from a 51% attack, "+
-			"giving it time to accumulate the necessary hash power.")
 	cmd.PersistentFlags().Uint64("trusted-block-producer-start-height", 37000,
 		"If --trusted-block-producer-public-keys is set, then all blocks after this height must "+
 			"be signed by one of these keys in order to be considered valid. Setting this value to zero "+


### PR DESCRIPTION
I am proud to announce that the dev community has committed to moving to
a decentralized consensus mechanism, and that it is taking a major step in
that direction with a new update.

Deso has gotten a lot of heat recently for lacking true
decentralization.

This is due in large part to "trusted producers," a consensus mechanism that
enables five keys to control the network.

Deso has relied on trusted producers to get off the ground, but since
launching the dev community has already invested in consensus mechanisms
that allow Deso to operate on orders of magnitude less control than
the existing trusted producers model.

Now, in a show of solidarity with the web 3.0 movement, and to
take the first big step toward a decentralized consensus mechanism,
Deso is deploying a new update that reduces its centralized control by
a full order of magnitude.

Deso is removing trusted producers, and thus the amount of
control its consensus mechanism incurs, by a factor of ten.

This was a difficult change to make, and it took the input of several
major node operators to deploy it safely.

We understand that the Deso Foundation in particular may not like this change;
however, there is now consensus around the decision to push the limits
of the Deso chain toward decentralization rather than allowing the
depletion of what are ultimately finite community resources.

There is still more work to do to move to a zero-control consensus
mechanism without compromising on centralization (e.g. distribution of supply).

But the dev community is committed to getting there sooner rather than
later, and we hope this change shows just how committed we are.