### PR TITLE
Remove logging before flags error.

### DIFF
--- a/migrate/init.go
+++ b/migrate/init.go
@@ -1,11 +1,8 @@
 package migrate
 
-import "github.com/golang/glog"
-
 // LoadMigrations forces Go to call init() on all the files in this package.
 // The library we use for migrations, go-pg-migrations, needs to be refactored to
 // not use this terrible loading pattern. It's hard to test, can cause weird side effects,
 // and is the reason we need this weird LoadMigrations method
 func LoadMigrations() {
-	glog.Info("Loading all migrations...")
 }


### PR DESCRIPTION
This was causing an error:
```
ERROR: logging before flag.Parse: I0318 10:00:15.265299    8558 init.go:10] Loading all migrations...
```
Removed this line resolved.