### PR TITLE
Update DAOCoinLimitOrderMetadata type so it can be serialized to json

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -1035,8 +1035,8 @@ func (bav *UtxoView) DisconnectBlock(
 		if txn.TxnMeta.GetTxnType() == TxnTypeDAOCoinLimitOrder {
 			numMatchingOrderInputs := 0
 
-			for _, inputs := range txn.TxnMeta.(*DAOCoinLimitOrderMetadata).MatchingBidsInputsMap {
-				numMatchingOrderInputs += len(inputs)
+			for _, transactor := range txn.TxnMeta.(*DAOCoinLimitOrderMetadata).MatchedBidSideTransactors {
+				numMatchingOrderInputs += len(transactor.Inputs)
 			}
 
 			numInputs += numMatchingOrderInputs

--- a/lib/block_view_dao_coin_limit_order.go
+++ b/lib/block_view_dao_coin_limit_order.go
@@ -156,7 +156,10 @@ func (bav *UtxoView) _connectDAOCoinLimitOrder(
 		pkidToLeftoverChangeDESONanos[*bav.GetPKIDForPublicKey(txn.PublicKey).PKID] = totalInput
 	}
 
-	for pkid, matchingBidsInputs := range txMeta.MatchingBidsInputsMap {
+	for _, transactor := range txMeta.MatchedBidSideTransactors {
+		pkid := *transactor.TransactorPKID
+		matchingBidSideInputs := transactor.Inputs
+
 		publicKey := bav.GetPublicKeyForPKID(&pkid)
 
 		// If no balance recorded so far, initialize to zero.
@@ -164,7 +167,7 @@ func (bav *UtxoView) _connectDAOCoinLimitOrder(
 			pkidToLeftoverChangeDESONanos[pkid] = 0
 		}
 
-		for _, matchingBidInput := range matchingBidsInputs {
+		for _, matchingBidInput := range matchingBidSideInputs {
 			utxoKey := UtxoKey(*matchingBidInput)
 			utxoEntry := bav.GetUtxoEntryForUtxoKey(&utxoKey)
 
@@ -933,8 +936,8 @@ func (bav *UtxoView) _disconnectDAOCoinLimitOrder(
 	// Now revert the basic transfer with the remaining operations.
 	numMatchingOrderInputs := 0
 
-	for _, inputs := range txMeta.MatchingBidsInputsMap {
-		numMatchingOrderInputs += len(inputs)
+	for _, transactor := range txMeta.MatchedBidSideTransactors {
+		numMatchingOrderInputs += len(transactor.Inputs)
 	}
 
 	numOrderOperations := (numUtxoAdds - len(currentTxn.TxOutputs) + numMatchingOrderInputs)

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -3238,7 +3238,7 @@ func (bc *Blockchain) CreateDAOCoinLimitOrderTxn(
 				lastSeenOrder = order
 			}
 		}
-		metadata.MatchingBidsInputsMap = make(map[PKID][]*DeSoInput)
+
 		for pkid, desoNanosToConsume := range desoNanosToConsumeMap {
 			var inputs []*DeSoInput
 			inputs, err = bc.GetInputsToCoverAmount(utxoView.GetPublicKeyForPKID(&pkid), utxoView, desoNanosToConsume)
@@ -3246,7 +3246,13 @@ func (bc *Blockchain) CreateDAOCoinLimitOrderTxn(
 				return nil, 0, 0, 0, errors.Wrapf(err,
 					"Blockchain.CreateDAOCoinLimitOrderTxn: Error getting inputs to cover amount: ")
 			}
-			metadata.MatchingBidsInputsMap[pkid] = inputs
+			metadata.MatchedBidSideTransactors = append(
+				metadata.MatchedBidSideTransactors,
+				&DeSoInputsByTransactorPKID{
+					TransactorPKID: &pkid,
+					Inputs:         inputs,
+				},
+			)
 		}
 	}
 


### PR DESCRIPTION
PKID is a type alias for byte array, which does not serialize directly to json. As a result the `DAOCoinLimitOrderMetadata` doesn't convert to json so it can be passed to the frontend. This PR does two things:
1) Changes the type of `MatchingBidsInputsMap` field from a map to a slice to address the above issue
2) Renames the field to `MatchedBidSideTransactors` so its clear that the utxo inputs are being grouped by transactor for the other side of the trade