### PR TITLE
Update DAOCoinLimitOrderMetadata type so it can be serialized to json

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -1035,8 +1035,8 @@ func (bav *UtxoView) DisconnectBlock(
 		if txn.TxnMeta.GetTxnType() == TxnTypeDAOCoinLimitOrder {
 			numMatchingOrderInputs := 0
 
-			for _, inputs := range txn.TxnMeta.(*DAOCoinLimitOrderMetadata).MatchingBidsInputsMap {
-				numMatchingOrderInputs += len(inputs)
+			for _, transactor := range txn.TxnMeta.(*DAOCoinLimitOrderMetadata).MatchedBidsTransactors {
+				numMatchingOrderInputs += len(transactor.Inputs)
 			}
 
 			numInputs += numMatchingOrderInputs

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -2729,7 +2729,7 @@ func (bc *Blockchain) CreateUpdateGlobalParamsTxn(updaterPublicKey []byte,
 	maxCopiesPerNFT int64,
 	minimumNetworkFeeNanosPerKb int64,
 	forbiddenPubKey []byte,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2778,10 +2778,10 @@ func (bc *Blockchain) CreateUpdateGlobalParamsTxn(updaterPublicKey []byte,
 }
 
 func (bc *Blockchain) CreateUpdateBitcoinUSDExchangeRateTxn(
-// Exchange rate update fields
+	// Exchange rate update fields
 	updaterPublicKey []byte,
 	usdCentsPerbitcoin uint64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2813,7 +2813,7 @@ func (bc *Blockchain) CreateUpdateBitcoinUSDExchangeRateTxn(
 }
 
 func (bc *Blockchain) CreateSubmitPostTxn(
-// Post fields
+	// Post fields
 	updaterPublicKey []byte,
 	postHashToModify []byte,
 	parentStakeID []byte,
@@ -2823,7 +2823,7 @@ func (bc *Blockchain) CreateSubmitPostTxn(
 	tstampNanos uint64,
 	postExtraData map[string][]byte,
 	isHidden bool,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2883,7 +2883,7 @@ func (bc *Blockchain) CreateSubmitPostTxn(
 
 func (bc *Blockchain) CreateUpdateProfileTxn(
 	UpdaterPublicKeyBytes []byte,
-// Optional. Only set when the owner of the profile is != to the updater.
+	// Optional. Only set when the owner of the profile is != to the updater.
 	OptionalProfilePublicKeyBytes []byte,
 	NewUsername string,
 	NewDescription string,
@@ -2893,7 +2893,7 @@ func (bc *Blockchain) CreateUpdateProfileTxn(
 	IsHidden bool,
 	AdditionalFees uint64,
 	ExtraData map[string][]byte,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2936,7 +2936,7 @@ func (bc *Blockchain) CreateSwapIdentityTxn(
 	FromPublicKeyBytes []byte,
 	ToPublicKeyBytes []byte,
 
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2970,7 +2970,7 @@ func (bc *Blockchain) CreateSwapIdentityTxn(
 
 func (bc *Blockchain) CreateCreatorCoinTxn(
 	UpdaterPublicKey []byte,
-// See CreatorCoinMetadataa for an explanation of these fields.
+	// See CreatorCoinMetadataa for an explanation of these fields.
 	ProfilePublicKey []byte,
 	OperationType CreatorCoinOperationType,
 	DeSoToSellNanos uint64,
@@ -2978,7 +2978,7 @@ func (bc *Blockchain) CreateCreatorCoinTxn(
 	DeSoToAddNanos uint64,
 	MinDeSoExpectedNanos uint64,
 	MinCreatorCoinExpectedNanos uint64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3025,7 +3025,7 @@ func (bc *Blockchain) CreateCreatorCoinTransferTxn(
 	ProfilePublicKey []byte,
 	CreatorCoinToTransferNanos uint64,
 	RecipientPublicKey []byte,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3064,9 +3064,9 @@ func (bc *Blockchain) CreateCreatorCoinTransferTxn(
 
 func (bc *Blockchain) CreateDAOCoinTxn(
 	UpdaterPublicKey []byte,
-// See CreatorCoinMetadataa for an explanation of these fields.
+	// See CreatorCoinMetadataa for an explanation of these fields.
 	metadata *DAOCoinMetadata,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3103,7 +3103,7 @@ func (bc *Blockchain) CreateDAOCoinTxn(
 func (bc *Blockchain) CreateDAOCoinTransferTxn(
 	UpdaterPublicKey []byte,
 	metadata *DAOCoinTransferMetadata,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3138,9 +3138,9 @@ func (bc *Blockchain) CreateDAOCoinTransferTxn(
 
 func (bc *Blockchain) CreateDAOCoinLimitOrderTxn(
 	UpdaterPublicKey []byte,
-// See DAOCoinLimitOrderMetadata for an explanation of these fields.
+	// See DAOCoinLimitOrderMetadata for an explanation of these fields.
 	metadata *DAOCoinLimitOrderMetadata,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 	// Create a transaction containing the create DAO coin limit order fields.
@@ -3296,7 +3296,7 @@ func (bc *Blockchain) CreateCreateNFTTxn(
 	AdditionalDESORoyalties map[PublicKey]uint64,
 	AdditionalCoinRoyalties map[PublicKey]uint64,
 	ExtraData map[string][]byte,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3421,7 +3421,7 @@ func (bc *Blockchain) CreateNFTBidTxn(
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
 	BidAmountNanos uint64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 	// Create a transaction containing the NFT bid fields.
@@ -3461,7 +3461,7 @@ func (bc *Blockchain) CreateNFTTransferTxn(
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
 	EncryptedUnlockableTextBytes []byte,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3500,7 +3500,7 @@ func (bc *Blockchain) CreateAcceptNFTTransferTxn(
 	UpdaterPublicKey []byte,
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3539,7 +3539,7 @@ func (bc *Blockchain) CreateBurnNFTTxn(
 	UpdaterPublicKey []byte,
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3579,7 +3579,7 @@ func (bc *Blockchain) CreateAcceptNFTBidTxn(
 	BidderPKID *PKID,
 	BidAmountNanos uint64,
 	EncryptedUnlockableTextBytes []byte,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3647,7 +3647,7 @@ func (bc *Blockchain) CreateUpdateNFTTxn(
 	MinBidAmountNanos uint64,
 	IsBuyNow bool,
 	BuyNowPriceNanos uint64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3756,7 +3756,7 @@ func (bc *Blockchain) CreateCreatorCoinTransferTxnWithDiamonds(
 	ReceiverPublicKey []byte,
 	DiamondPostHash *BlockHash,
 	DiamondLevel int64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3838,7 +3838,7 @@ func (bc *Blockchain) CreateAuthorizeDerivedKeyTxn(
 	extraData map[string][]byte,
 	memo []byte,
 	transactionSpendingLimit *TransactionSpendingLimit,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3977,7 +3977,7 @@ func (bc *Blockchain) CreateBasicTransferTxnWithDiamonds(
 	SenderPublicKey []byte,
 	DiamondPostHash *BlockHash,
 	DiamondLevel int64,
-// Standard transaction fields
+	// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _spendAmount uint64, _changeAmount uint64, _fees uint64, _err error) {
 

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -2729,7 +2729,7 @@ func (bc *Blockchain) CreateUpdateGlobalParamsTxn(updaterPublicKey []byte,
 	maxCopiesPerNFT int64,
 	minimumNetworkFeeNanosPerKb int64,
 	forbiddenPubKey []byte,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2778,10 +2778,10 @@ func (bc *Blockchain) CreateUpdateGlobalParamsTxn(updaterPublicKey []byte,
 }
 
 func (bc *Blockchain) CreateUpdateBitcoinUSDExchangeRateTxn(
-	// Exchange rate update fields
+// Exchange rate update fields
 	updaterPublicKey []byte,
 	usdCentsPerbitcoin uint64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2813,7 +2813,7 @@ func (bc *Blockchain) CreateUpdateBitcoinUSDExchangeRateTxn(
 }
 
 func (bc *Blockchain) CreateSubmitPostTxn(
-	// Post fields
+// Post fields
 	updaterPublicKey []byte,
 	postHashToModify []byte,
 	parentStakeID []byte,
@@ -2823,7 +2823,7 @@ func (bc *Blockchain) CreateSubmitPostTxn(
 	tstampNanos uint64,
 	postExtraData map[string][]byte,
 	isHidden bool,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2883,7 +2883,7 @@ func (bc *Blockchain) CreateSubmitPostTxn(
 
 func (bc *Blockchain) CreateUpdateProfileTxn(
 	UpdaterPublicKeyBytes []byte,
-	// Optional. Only set when the owner of the profile is != to the updater.
+// Optional. Only set when the owner of the profile is != to the updater.
 	OptionalProfilePublicKeyBytes []byte,
 	NewUsername string,
 	NewDescription string,
@@ -2893,7 +2893,7 @@ func (bc *Blockchain) CreateUpdateProfileTxn(
 	IsHidden bool,
 	AdditionalFees uint64,
 	ExtraData map[string][]byte,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2936,7 +2936,7 @@ func (bc *Blockchain) CreateSwapIdentityTxn(
 	FromPublicKeyBytes []byte,
 	ToPublicKeyBytes []byte,
 
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -2970,7 +2970,7 @@ func (bc *Blockchain) CreateSwapIdentityTxn(
 
 func (bc *Blockchain) CreateCreatorCoinTxn(
 	UpdaterPublicKey []byte,
-	// See CreatorCoinMetadataa for an explanation of these fields.
+// See CreatorCoinMetadataa for an explanation of these fields.
 	ProfilePublicKey []byte,
 	OperationType CreatorCoinOperationType,
 	DeSoToSellNanos uint64,
@@ -2978,7 +2978,7 @@ func (bc *Blockchain) CreateCreatorCoinTxn(
 	DeSoToAddNanos uint64,
 	MinDeSoExpectedNanos uint64,
 	MinCreatorCoinExpectedNanos uint64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3025,7 +3025,7 @@ func (bc *Blockchain) CreateCreatorCoinTransferTxn(
 	ProfilePublicKey []byte,
 	CreatorCoinToTransferNanos uint64,
 	RecipientPublicKey []byte,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3064,9 +3064,9 @@ func (bc *Blockchain) CreateCreatorCoinTransferTxn(
 
 func (bc *Blockchain) CreateDAOCoinTxn(
 	UpdaterPublicKey []byte,
-	// See CreatorCoinMetadataa for an explanation of these fields.
+// See CreatorCoinMetadataa for an explanation of these fields.
 	metadata *DAOCoinMetadata,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3103,7 +3103,7 @@ func (bc *Blockchain) CreateDAOCoinTxn(
 func (bc *Blockchain) CreateDAOCoinTransferTxn(
 	UpdaterPublicKey []byte,
 	metadata *DAOCoinTransferMetadata,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3138,9 +3138,9 @@ func (bc *Blockchain) CreateDAOCoinTransferTxn(
 
 func (bc *Blockchain) CreateDAOCoinLimitOrderTxn(
 	UpdaterPublicKey []byte,
-	// See DAOCoinLimitOrderMetadata for an explanation of these fields.
+// See DAOCoinLimitOrderMetadata for an explanation of these fields.
 	metadata *DAOCoinLimitOrderMetadata,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 	// Create a transaction containing the create DAO coin limit order fields.
@@ -3240,7 +3240,7 @@ func (bc *Blockchain) CreateDAOCoinLimitOrderTxn(
 				lastSeenOrder = matchingOrder
 			}
 		}
-		metadata.MatchingBidsInputsMap = make(map[PublicKey][]*DeSoInput)
+
 		for pkid, desoNanosToConsume := range desoNanosToConsumeMap {
 			var inputs []*DeSoInput
 			publicKey := NewPublicKey(utxoView.GetPublicKeyForPKID(&pkid))
@@ -3250,7 +3250,15 @@ func (bc *Blockchain) CreateDAOCoinLimitOrderTxn(
 				return nil, 0, 0, 0, errors.Wrapf(err,
 					"Blockchain.CreateDAOCoinLimitOrderTxn: Error getting inputs to cover amount: ")
 			}
-			metadata.MatchingBidsInputsMap[*publicKey] = inputs
+			publicKeyCopy := *publicKey
+
+			metadata.MatchedBidsTransactors = append(
+				metadata.MatchedBidsTransactors,
+				&DeSoInputsByTransactor{
+					TransactorPublicKey: &publicKeyCopy,
+					Inputs:              inputs,
+				},
+			)
 		}
 	}
 
@@ -3288,7 +3296,7 @@ func (bc *Blockchain) CreateCreateNFTTxn(
 	AdditionalDESORoyalties map[PublicKey]uint64,
 	AdditionalCoinRoyalties map[PublicKey]uint64,
 	ExtraData map[string][]byte,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3413,7 +3421,7 @@ func (bc *Blockchain) CreateNFTBidTxn(
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
 	BidAmountNanos uint64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 	// Create a transaction containing the NFT bid fields.
@@ -3453,7 +3461,7 @@ func (bc *Blockchain) CreateNFTTransferTxn(
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
 	EncryptedUnlockableTextBytes []byte,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3492,7 +3500,7 @@ func (bc *Blockchain) CreateAcceptNFTTransferTxn(
 	UpdaterPublicKey []byte,
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3531,7 +3539,7 @@ func (bc *Blockchain) CreateBurnNFTTxn(
 	UpdaterPublicKey []byte,
 	NFTPostHash *BlockHash,
 	SerialNumber uint64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3571,7 +3579,7 @@ func (bc *Blockchain) CreateAcceptNFTBidTxn(
 	BidderPKID *PKID,
 	BidAmountNanos uint64,
 	EncryptedUnlockableTextBytes []byte,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3639,7 +3647,7 @@ func (bc *Blockchain) CreateUpdateNFTTxn(
 	MinBidAmountNanos uint64,
 	IsBuyNow bool,
 	BuyNowPriceNanos uint64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3748,7 +3756,7 @@ func (bc *Blockchain) CreateCreatorCoinTransferTxnWithDiamonds(
 	ReceiverPublicKey []byte,
 	DiamondPostHash *BlockHash,
 	DiamondLevel int64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3830,7 +3838,7 @@ func (bc *Blockchain) CreateAuthorizeDerivedKeyTxn(
 	extraData map[string][]byte,
 	memo []byte,
 	transactionSpendingLimit *TransactionSpendingLimit,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _changeAmount uint64, _fees uint64, _err error) {
 
@@ -3969,7 +3977,7 @@ func (bc *Blockchain) CreateBasicTransferTxnWithDiamonds(
 	SenderPublicKey []byte,
 	DiamondPostHash *BlockHash,
 	DiamondLevel int64,
-	// Standard transaction fields
+// Standard transaction fields
 	minFeeRateNanosPerKB uint64, mempool *DeSoMempool, additionalOutputs []*DeSoOutput) (
 	_txn *MsgDeSoTxn, _totalInput uint64, _spendAmount uint64, _changeAmount uint64, _fees uint64, _err error) {
 

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -3250,16 +3250,19 @@ func (bc *Blockchain) CreateDAOCoinLimitOrderTxn(
 				return nil, 0, 0, 0, errors.Wrapf(err,
 					"Blockchain.CreateDAOCoinLimitOrderTxn: Error getting inputs to cover amount: ")
 			}
-			publicKeyCopy := *publicKey
 
-			metadata.MatchedBidsTransactors = append(
-				metadata.MatchedBidsTransactors,
-				&DeSoInputsByTransactor{
-					TransactorPublicKey: &publicKeyCopy,
-					Inputs:              inputs,
-				},
-			)
+			inputsByTransactor := DeSoInputsByTransactor{
+				TransactorPublicKey: &(*publicKey), // create a pointer to a copy of the public key
+				Inputs:              inputs,
+			}
+			// Sort Inputs
+			inputsByTransactor.Inputs = inputsByTransactor.GetInputsSorted()
+
+			metadata.MatchedBidsTransactors = append(metadata.MatchedBidsTransactors, &inputsByTransactor)
 		}
+
+		// Sort MatchedBidsTransactors
+		metadata.MatchedBidsTransactors = metadata.GetMatchedBidTransactorsSorted()
 	}
 
 	// Add inputs and change for a standard pay per KB transaction.

--- a/lib/network.go
+++ b/lib/network.go
@@ -5490,6 +5490,11 @@ func (txnData *DAOCoinTransferMetadata) New() DeSoTxnMetadata {
 // DAOCoinLimitOrderMetadata
 // ==================================================================
 
+type DeSoInputsByTransactor struct {
+	TransactorPublicKey *PublicKey
+	Inputs              []*DeSoInput
+}
+
 type DAOCoinLimitOrderMetadata struct {
 	BuyingDAOCoinCreatorPublicKey             *PublicKey
 	SellingDAOCoinCreatorPublicKey            *PublicKey
@@ -5500,9 +5505,11 @@ type DAOCoinLimitOrderMetadata struct {
 	// specified quantity) instead of creating a new one.
 	CancelExistingOrder bool
 
-	// This map is populated with the inputs consumed when a transaction
-	// is an ask offer and there are bids to match immediately.
-	MatchingBidsInputsMap map[PublicKey][]*DeSoInput
+	// This is only populated when this order is selling a DAO coin for
+	// $DESO, and is immediately matched with an existing bid-side order
+	// at time of creation. This field contains the transactor and their
+	// utxo inputs that can be used to immediately execute this trade.
+	MatchedBidsTransactors []*DeSoInputsByTransactor
 }
 
 func (txnData *DAOCoinLimitOrderMetadata) GetTxnType() TxnType {
@@ -5515,40 +5522,12 @@ func (txnData *DAOCoinLimitOrderMetadata) ToBytes(preSignature bool) ([]byte, er
 	data = append(data, EncodeUint256(txnData.ScaledExchangeRateCoinsToSellPerCoinToBuy)...)
 	data = append(data, EncodeUint256(txnData.QuantityToBuyInBaseUnits)...)
 	data = append(data, BoolToByte(txnData.CancelExistingOrder))
-	data = append(data, UintToBuf(uint64(len(txnData.MatchingBidsInputsMap)))...)
+	data = append(data, UintToBuf(uint64(len(txnData.MatchedBidsTransactors)))...)
 
-	// Maps MUST be iterated in sorted order or else the serialization of the txn
-	// will be non-deterministic. This is very bad because it results in the txn
-	// hash being different each time.
-	//
-	// We sort the keys based on the mainnet string encoding of the public key.
-	sortedBidderPkStrings := []string{}
-	for bidderPkIter, _ := range txnData.MatchingBidsInputsMap {
-		// You must make a copy of the iterator before taking a pointer of it.
-		// If you don't do this, you'll have one of the worst bugs you've ever
-		// had to deal with, where the underlying data of all your pointers is
-		// shifted under your feet. It's not needed here because we're not saving
-		// the pointer, but do it just to be safe.
-		bidderPk := bidderPkIter
-		sortedBidderPkStrings = append(sortedBidderPkStrings, PkToStringMainnet(bidderPk[:]))
-	}
-	for ii, pkStr := range sortedBidderPkStrings {
-		bidderPkBytes, _, err := Base58CheckDecode(pkStr)
-		if err != nil {
-			return nil, errors.Wrapf(err, "DAOCoinLimitOrderMetadata: "+
-				"Error serializing pubkey %v at index %v in MatchingBidsInputsMap",
-				pkStr, ii)
-		}
-		bidderPk := NewPublicKey(bidderPkBytes)
-		inputs, exists := txnData.MatchingBidsInputsMap[*bidderPk]
-		if !exists {
-			return nil, fmt.Errorf("DAOCoinLimitOrderMetadata: Error "+
-				"serializing inputs for pubkey %v at index %v. Map value "+
-				"did not exist. This should never happen", pkStr, ii)
-		}
-		data = append(data, bidderPk[:]...)
-		data = append(data, UintToBuf(uint64(len(inputs)))...)
-		for _, input := range inputs {
+	for _, transactor := range txnData.MatchedBidsTransactors {
+		data = append(data, transactor.TransactorPublicKey[:]...)
+		data = append(data, UintToBuf(uint64(len(transactor.Inputs)))...)
+		for _, input := range transactor.Inputs {
 			data = append(data, input.TxID[:]...)
 			data = append(data, UintToBuf(uint64(input.Index))...)
 		}
@@ -5597,18 +5576,14 @@ func (txnData *DAOCoinLimitOrderMetadata) FromBytes(data []byte) error {
 	// Parse CancelExistingOrder
 	ret.CancelExistingOrder = ReadBoolByte(rr)
 
-	// Parse MatchingBidsInputsMap
-	matchingBidsInputsMapLength, err := ReadUvarint(rr)
+	// Parse MatchingBidsTransactors
+	matchingBidsTransactorsLength, err := ReadUvarint(rr)
 	if err != nil {
 		return fmt.Errorf(
 			"DAOCoinLimitOrderMetadata.FromBytes: Error reading length of matching bids input: %v", err)
 	}
 
-	if matchingBidsInputsMapLength > 0 {
-		ret.MatchingBidsInputsMap = make(map[PublicKey][]*DeSoInput)
-	}
-
-	for ii := uint64(0); ii < matchingBidsInputsMapLength; ii++ {
+	for ii := uint64(0); ii < matchingBidsTransactorsLength; ii++ {
 		pubKey, err := ReadPublicKey(rr)
 		if err != nil {
 			return fmt.Errorf(
@@ -5620,7 +5595,7 @@ func (txnData *DAOCoinLimitOrderMetadata) FromBytes(data []byte) error {
 			return fmt.Errorf(
 				"DAOCoinLimitOrderMetadata.FromBytes: Error reading inputs length at index %v: %v", ii, err)
 		}
-		ret.MatchingBidsInputsMap[*pubKey] = make([]*DeSoInput, 0, matchingBidsInputsMapLength)
+		inputs := []*DeSoInput{}
 		for jj := uint64(0); jj < inputsLength; jj++ {
 			currentInput := NewDeSoInput()
 			_, err = io.ReadFull(rr, currentInput.TxID[:])
@@ -5643,9 +5618,17 @@ func (txnData *DAOCoinLimitOrderMetadata) FromBytes(data []byte) error {
 			}
 			currentInput.Index = uint32(inputIndex)
 
-			ret.MatchingBidsInputsMap[*pubKey] = append(
-				ret.MatchingBidsInputsMap[*pubKey], currentInput)
+			inputs = append(inputs, currentInput)
 		}
+
+		pubKeyCopy := *pubKey
+		ret.MatchedBidsTransactors = append(
+			ret.MatchedBidsTransactors,
+			&DeSoInputsByTransactor{
+				TransactorPublicKey: &pubKeyCopy,
+				Inputs:              inputs,
+			},
+		)
 	}
 
 	*txnData = ret


### PR DESCRIPTION
PKID is a type alias for byte array, which does not serialize directly to json. As a result the `DAOCoinLimitOrderMetadata` doesn't convert to json so it can be passed to the frontend. This PR does two things:
1) Changes the type of `MatchingBidsInputsMap` field from a map to a slice to address the above issue
2) Renames the field to `MatchedBidsTransactors` so its clear that the utxo inputs are being grouped by transactor when forming the other side of the trade