### PR TITLE
Fix segfault when copying DerivedKeyEntry

### DIFF
--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -985,7 +985,9 @@ func (dk *DerivedKeyEntry) Copy() *DerivedKeyEntry {
 		return nil
 	}
 	newEntry := *dk
-	newEntry.TransactionSpendingLimitTracker = dk.TransactionSpendingLimitTracker.Copy()
+	if dk.TransactionSpendingLimitTracker != nil {
+		newEntry.TransactionSpendingLimitTracker = dk.TransactionSpendingLimitTracker.Copy()
+	}
 	return &newEntry
 }
 

--- a/lib/network.go
+++ b/lib/network.go
@@ -4868,6 +4868,9 @@ func (tsl *TransactionSpendingLimit) FromBytes(data []byte) error {
 }
 
 func (tsl *TransactionSpendingLimit) Copy() *TransactionSpendingLimit {
+	if tsl == nil {
+		return nil
+	}
 	copyTSL := &TransactionSpendingLimit{
 		GlobalDESOLimit:              tsl.GlobalDESOLimit,
 		TransactionCountLimitMap:     make(map[TxnType]uint64),


### PR DESCRIPTION
Only copy TransactionSpendingLimitTracker if non-nil, (tsl *TransactionSpendingLimit) Copy() should return nil if tsl is nil