### PR TITLE
[TESTNET HARD FORK]: Update TESTNET block heights for DAOSwap hard fork

### DIFF
--- a/lib/constants.go
+++ b/lib/constants.go
@@ -850,6 +850,9 @@ var DeSoTestnetParams = DeSoParams{
 	CreatorCoinAutoSellThresholdNanos: uint64(10),
 
 	ForkHeights: ForkHeights{
+		// Get testnet height from here:
+		// - https://explorer.deso.org/?query-node=https:%2F%2Ftest.deso.org
+
 		// Initially, testnet fork heights were the same as mainnet heights
 		// This changed when we spun up a real testnet that runs independently
 		DeflationBombBlockHeight:                             33783,
@@ -869,15 +872,11 @@ var DeSoTestnetParams = DeSoParams{
 		BuyNowAndNFTSplitsBlockHeight: uint32(97322),
 		DAOCoinBlockHeight:            uint32(97322),
 
-		// FIXME: set to real block height
-		ExtraDataOnEntriesBlockHeight: math.MaxUint32,
-
-		// FIXME: Set these values when we're ready for the next fork.
-		DerivedKeySetSpendingLimitsBlockHeight:   math.MaxUint32,
-		DerivedKeyTrackSpendingLimitsBlockHeight: math.MaxUint32,
-
-		// FIXME: Set to real block height when we're ready.
-		DAOCoinLimitOrderBlockHeight: math.MaxUint32,
+		// Wed Apr 20 @ 9am ET
+		ExtraDataOnEntriesBlockHeight:            uint32(304087),
+		DerivedKeySetSpendingLimitsBlockHeight:   uint32(304087),
+		DerivedKeyTrackSpendingLimitsBlockHeight: uint32(304087),
+		DAOCoinLimitOrderBlockHeight:             uint32(304087),
 	},
 }
 


### PR DESCRIPTION
The following hard forks are triggering on Testnet on Wed Apr 20 @ 9am
ET:
    ExtraDataOnEntriesBlockHeight:            uint32(304087),
    DerivedKeySetSpendingLimitsBlockHeight:   uint32(304087),
    DerivedKeyTrackSpendingLimitsBlockHeight: uint32(304087),
    DAOCoinLimitOrderBlockHeight:             uint32(304087),