### PR TITLE
Support DAOCoinLimitOrder cancels for derived keys

### DIFF
--- a/lib/errors.go
+++ b/lib/errors.go
@@ -402,6 +402,7 @@ const (
 	RuleErrorDerivedKeyNFTOperationNotAuthorized         RuleError = "RuleErrorDerivedKeyNFTOperationNotAuthorized"
 	RuleErrorDerivedKeyCreatorCoinOperationNotAuthorized RuleError = "RuleErrorDerivedKeyCreatorCoinOperationNotAuthorized"
 	RuleErrorDerivedKeyDAOCoinOperationNotAuthorized     RuleError = "RuleErrorDerivedKeyDAOCoinOperationNotAuthorized"
+	RuleErrorDerivedKeyInvalidDAOCoinLimitOrderOrderID   RuleError = "RuleErrorDerivedKeyInvalidDAOCoinLimitOrderOrderID"
 	RuleErrorDerivedKeyDAOCoinLimitOrderNotAuthorized    RuleError = "RuleErrorDerivedKeyDAOCoinLimitOrderNotAuthorized"
 
 	HeaderErrorDuplicateHeader                                                   RuleError = "HeaderErrorDuplicateHeader"


### PR DESCRIPTION
Derived keys can't cancel DAO coin limit orders since the spending limit lookup requires the buying & selling coin public keys to always be specified in the transaction metadata. We side-step this by first using order id to look up the order entry, and using the buying & selling pkids from there.

It doesn't appear we need any changes in the disconnect logic. The affected transactions disconnect as expected in the tests.