### PR TITLE
Set mainnet block heights for DAODAO hard fork

### DIFF
--- a/lib/constants.go
+++ b/lib/constants.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/holiman/uint256"
 	"log"
-	"math"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -237,7 +236,8 @@ type ForkHeights struct {
 	// DAOCoinLimitOrderBlockHeight defines the height at which DAO Coin Limit Order transactions will be accepted.
 	DAOCoinLimitOrderBlockHeight uint32
 
-	// Be sure to update EncoderMigrationHeights as well if you're modifying schema.
+	// Be sure to update EncoderMigrationHeights as well via
+	// GetEncoderMigrationHeights if you're modifying schema.
 }
 
 // EncoderMigrationHeights is used to store migration heights for DeSoEncoder types. To properly migrate a DeSoEncoder,
@@ -544,7 +544,8 @@ var RegtestForkHeights = ForkHeights{
 	DerivedKeyTrackSpendingLimitsBlockHeight:             uint32(0),
 	DAOCoinLimitOrderBlockHeight:                         uint32(0),
 
-	// Be sure to update EncoderMigrationHeights as well if you're modifying schema.
+	// Be sure to update EncoderMigrationHeights as well via
+	// GetEncoderMigrationHeights if you're modifying schema.
 }
 
 // EnableRegtest allows for local development and testing with incredibly fast blocks with block rewards that
@@ -647,17 +648,13 @@ var MainnetForkHeights = ForkHeights{
 	BuyNowAndNFTSplitsBlockHeight: uint32(98474),
 	DAOCoinBlockHeight:            uint32(98474),
 
-	// FIXME: set to real block height
-	ExtraDataOnEntriesBlockHeight: math.MaxUint32,
+	ExtraDataOnEntriesBlockHeight:            uint32(130901),
+	DerivedKeySetSpendingLimitsBlockHeight:   uint32(130901),
+	DerivedKeyTrackSpendingLimitsBlockHeight: uint32(130901),
+	DAOCoinLimitOrderBlockHeight:             uint32(130901),
 
-	// FIXME: Set these values when we're ready for the next fork.
-	DerivedKeySetSpendingLimitsBlockHeight:   math.MaxUint32,
-	DerivedKeyTrackSpendingLimitsBlockHeight: math.MaxUint32,
-
-	// FIXME: Set to real block height when we're ready.
-	DAOCoinLimitOrderBlockHeight: math.MaxUint32,
-
-	// Be sure to update EncoderMigrationHeights as well if you're modifying schema.
+	// Be sure to update EncoderMigrationHeights as well via
+	// GetEncoderMigrationHeights if you're modifying schema.
 }
 
 // DeSoMainnetParams defines the DeSo parameters for the mainnet.
@@ -898,7 +895,8 @@ var TestnetForkHeights = ForkHeights{
 	DerivedKeyTrackSpendingLimitsBlockHeight: uint32(304087 + 18*60),
 	DAOCoinLimitOrderBlockHeight:             uint32(304087),
 
-	// Be sure to update EncoderMigrationHeights as well if you're modifying schema.
+	// Be sure to update EncoderMigrationHeights as well via
+	// GetEncoderMigrationHeights if you're modifying schema.
 }
 
 // DeSoTestnetParams defines the DeSo parameters for the testnet.


### PR DESCRIPTION
Hard fork date: Wednesday at 2pm PT (~8.5 days from now)

Computing 1 week of blocks:
 * Actual block diff for 7 days from block explorer:
   - 128309 (today)
     * Mon May 09 2022 13:55:28 GMT-0700 (Pacific Daylight Time)
   - 126339 (7 days ago)
     * Mon May 02 2022 13:42:51 GMT-0700 (Pacific Daylight Time)
   - = 1970 blocks
 * From calculations:
   - 288 * 7 - 2016
 * Sanity-check:
   - (2016-1970) = 46 blocks diff
   - ~2.3% difference = 3.8 hours (not a big deal)
   - This is actually good because it means that we have some buffer

Computing blocks from now until hard fork
 * 128309
   - Mon May 09 2022 13:55:28 GMT-0700 (Pacific Daylight Time)
 * Add precisely 9 days of blocks:
   - 9 * 288 = 2592 blocks
   - 128309 + 2592 = 130901