### PR TITLE
Fix RawDecodeWithoutMetadata for NFTBidEntryBundle

### DIFF
--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -2534,7 +2534,7 @@ func (bundle *NFTBidEntryBundle) RawDecodeWithoutMetadata(blockHeight uint64, rr
 		if exists, err := DecodeFromBytes(bidEntry, rr); !exists || err != nil {
 			return errors.Wrapf(err, "NFTBidEntryBundle.RawDecodeWithoutMetadata: Problem decoding nft bids at index ii: %v", ii)
 		}
-		bundle.nftBidEntryBundle = append(bundle.nftBidEntryBundle, bidEntry)
+		bundle.nftBidEntryBundle[ii] = bidEntry
 	}
 
 	return nil


### PR DESCRIPTION
Currently, we initialize a slice of BidEntries with the expected length and then append to this slice. This results in a slice that is twice the length expected with the first half of the slice as nil BidEntries. 

To resolve this, we set the index in the slice to the decoded bid entry directly.