### PR TITLE
State check on disconnect tests

### DIFF
--- a/lib/block_view_creator_coin_test.go
+++ b/lib/block_view_creator_coin_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"reflect"
 	"testing"
 )
 
@@ -584,6 +585,11 @@ func _helpTestCreatorCoinBuySell(
 	assert.Equalf(int64(m6StartNanos),
 		int64(_getBalance(t, chain, nil, m6Pub)), "m6 DeSo balance after SimpleDisconnect is incorrect")
 
+	checksumBefore, err := _computeChecksumOfCurrentDatabase(db, 0)
+	require.NoError(err)
+	checksumBeforeBytes, err := checksumBefore.ToBytes()
+	require.NoError(err)
+
 	// Connect all the txns to a single UtxoView without flushing
 	{
 		// Create a new UtxoView to check on the state of things
@@ -649,6 +655,12 @@ func _helpTestCreatorCoinBuySell(
 		assert.Equalf(int64(m6StartNanos),
 			int64(_getBalance(t, chain, nil, m6Pub)), "m6 DeSo balance after BatchDisconnect is incorrect")
 	}
+
+	checksumAfter, err := _computeChecksumOfCurrentDatabase(db, 0)
+	require.NoError(err)
+	checksumAfterBytes, err := checksumAfter.ToBytes()
+	require.NoError(err)
+	require.Equal(true, reflect.DeepEqual(checksumBeforeBytes, checksumAfterBytes))
 
 	// Running all the transactions through the mempool should work and result
 	// in all of them being added.

--- a/lib/block_view_dao_coin_test.go
+++ b/lib/block_view_dao_coin_test.go
@@ -1188,9 +1188,5 @@ func TestDAOCoinBasic(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }

--- a/lib/block_view_message_test.go
+++ b/lib/block_view_message_test.go
@@ -1595,11 +1595,7 @@ func TestMessagingKeys(t *testing.T) {
 	_verifyAddedMessagingKeys(testMeta, m3PubKey, keyEntriesAdded[m3PublicKey])
 
 	// Do some block connecting/disconnecting, mempooling, etc to verify everything works.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 
 	// Finally, verify that there are no more keys, besides the base keys, in the db.
 	{
@@ -2402,11 +2398,7 @@ func TestGroupMessages(t *testing.T) {
 	}
 
 	// Now disconnect all entries.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 
 	// Sanity-check that all entries were reverted from the DB.
 	utxoView, err := NewUtxoView(db, params, nil, chain.snapshot)

--- a/lib/block_view_nft_test.go
+++ b/lib/block_view_nft_test.go
@@ -1636,11 +1636,7 @@ func TestNFTBasic(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTRoyaltiesAndSpendingOfBidderUTXOs(t *testing.T) {
@@ -2171,11 +2167,7 @@ func TestNFTRoyaltiesAndSpendingOfBidderUTXOs(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTSerialNumberZeroBid(t *testing.T) {
@@ -2499,11 +2491,7 @@ func TestNFTSerialNumberZeroBid(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTMinimumBidAmount(t *testing.T) {
@@ -2750,11 +2738,7 @@ func TestNFTMinimumBidAmount(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 // Test to make sure an NFT created with "IsForSale=false" does not accept bids.
@@ -2960,11 +2944,7 @@ func TestNFTCreatedIsNotForSale(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTMoreErrorCases(t *testing.T) {
@@ -3315,11 +3295,7 @@ func TestNFTMoreErrorCases(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTBidsAreCanceledAfterAccept(t *testing.T) {
@@ -3601,11 +3577,7 @@ func TestNFTBidsAreCanceledAfterAccept(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTDifferentMinBidAmountSerialNumbers(t *testing.T) {
@@ -3892,11 +3864,7 @@ func TestNFTDifferentMinBidAmountSerialNumbers(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTMaxCopiesGlobalParam(t *testing.T) {
@@ -4206,11 +4174,7 @@ func TestNFTMaxCopiesGlobalParam(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTPreviousOwnersCantAcceptBids(t *testing.T) {
@@ -4500,11 +4464,7 @@ func TestNFTPreviousOwnersCantAcceptBids(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTTransfersAndBurns(t *testing.T) {
@@ -5006,11 +4966,7 @@ func TestNFTTransfersAndBurns(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestBidAmountZero(t *testing.T) {
@@ -5216,12 +5172,7 @@ func TestBidAmountZero(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
-
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTBuyNow(t *testing.T) {
@@ -6234,11 +6185,7 @@ func TestNFTBuyNow(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTSplits(t *testing.T) {
@@ -7192,11 +7139,7 @@ func TestNFTSplits(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestNFTSplitsSerializers(t *testing.T) {
@@ -7682,9 +7625,5 @@ func TestNFTSplitsHardcorePKIDBug(t *testing.T) {
 		)
 	}
 
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }

--- a/lib/block_view_post_test.go
+++ b/lib/block_view_post_test.go
@@ -1843,11 +1843,7 @@ func TestDeSoDiamonds(t *testing.T) {
 	}
 
 	// Roll all successful txns through connect and disconnect loops to make sure nothing breaks.
-	_rollBackTestMetaTxnsAndFlush(testMeta)
-	_applyTestMetaTxnsToMempool(testMeta)
-	_applyTestMetaTxnsToViewAndFlush(testMeta)
-	_disconnectTestMetaTxnsFromViewAndFlush(testMeta)
-	_connectBlockThenDisconnectBlockAndFlush(testMeta)
+	_executeAllTestRollbackAndFlush(testMeta)
 }
 
 func TestDeSoDiamondErrorCases(t *testing.T) {

--- a/lib/block_view_test.go
+++ b/lib/block_view_test.go
@@ -341,7 +341,6 @@ func _applyAndDisconnectTestMetaTxnToViewAndFlushWithStateChecks(testMeta *TestM
 	// Flush the utxoView after having added all the transactions.
 	require.NoError(testMeta.t, utxoView.FlushToDb(0))
 
-
 	// Disonnect the transactions from a single view in the same way as above
 	// i.e. without flushing each time.
 	utxoView, err = NewUtxoView(testMeta.db, testMeta.params, testMeta.chain.postgres, testMeta.chain.snapshot)
@@ -403,10 +402,10 @@ func _computeChecksumOfCurrentDatabase(db *badger.DB, blockHeight uint64) (_chec
 	singleChecksum := &StateChecksum{}
 	singleChecksum.Initialize(nil, nil)
 	checksumArray := append([]*EncoderMigrationChecksum{}, &EncoderMigrationChecksum{
-		Checksum: singleChecksum,
+		Checksum:    singleChecksum,
 		BlockHeight: blockHeight,
-		Version: byte(0),
-		Completed: false,
+		Version:     byte(0),
+		Completed:   false,
 	})
 
 	// Get all state prefixes and sort them.


### PR DESCRIPTION
Add some checks to disconnect tests:
- verify that the state prior to transaction connects is identical to the state after transaction disconnects
- simplify TestMeta mempool/block disconnects everywhere

This PR has zero impact on the chain.