### PR TITLE
fix CI error "Could not open temp db to dump mempool"

### DIFF
--- a/lib/block_view_bitcoin_test.go
+++ b/lib/block_view_bitcoin_test.go
@@ -76,6 +76,7 @@ func _dumpAndLoadMempool(mempool *DeSoMempool) {
 		0 /* minFeeRateNanosPerKB */, "", true,
 		mempool.dataDir, "")
 	mempool.mempoolDir = ""
+	newMempool.LoadTxnsFromDB()
 	mempool.resetPool(newMempool)
 }
 

--- a/lib/block_view_bitcoin_test.go
+++ b/lib/block_view_bitcoin_test.go
@@ -75,7 +75,6 @@ func _dumpAndLoadMempool(mempool *DeSoMempool) {
 		mempool.bc, 0, /* rateLimitFeeRateNanosPerKB */
 		0 /* minFeeRateNanosPerKB */, "", true,
 		mempool.dataDir, "")
-	mempool.mempoolDir = ""
 	newMempool.mempoolDir = mempoolDir
 	newMempool.LoadTxnsFromDB()
 	mempool.resetPool(newMempool)

--- a/lib/block_view_bitcoin_test.go
+++ b/lib/block_view_bitcoin_test.go
@@ -76,6 +76,7 @@ func _dumpAndLoadMempool(mempool *DeSoMempool) {
 		0 /* minFeeRateNanosPerKB */, "", true,
 		mempool.dataDir, "")
 	mempool.mempoolDir = ""
+	newMempool.mempoolDir = mempoolDir
 	newMempool.LoadTxnsFromDB()
 	mempool.resetPool(newMempool)
 }

--- a/lib/block_view_bitcoin_test.go
+++ b/lib/block_view_bitcoin_test.go
@@ -74,7 +74,7 @@ func _dumpAndLoadMempool(mempool *DeSoMempool) {
 	newMempool := NewDeSoMempool(
 		mempool.bc, 0, /* rateLimitFeeRateNanosPerKB */
 		0 /* minFeeRateNanosPerKB */, "", true,
-		mempool.dataDir, mempoolDir)
+		mempool.dataDir, "")
 	mempool.mempoolDir = ""
 	mempool.resetPool(newMempool)
 }

--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -702,8 +702,6 @@ func (mp *DeSoMempool) isUnconnectedTxnInPool(hash *BlockHash) bool {
 
 func (mp *DeSoMempool) DumpTxnsToDB() {
 	// Dump all mempool txns into data_dir_path/temp_mempool_dump.
-	mp.mtx.Lock()
-	defer mp.mtx.Unlock()
 	err := mp.OpenTempDBAndDumpTxns()
 	if err != nil {
 		glog.Infof("DumpTxnsToDB: Problem opening temp db / dumping mempool txns: %v", err)
@@ -759,6 +757,8 @@ func MakeDirIfNonExistent(filePath string) error {
 }
 
 func (mp *DeSoMempool) OpenTempDBAndDumpTxns() error {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
 	blockHeight := uint64(mp.bc.blockTip().Height + 1)
 	allTxns := mp.readOnlyUniversalTransactionList
 

--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -702,6 +702,8 @@ func (mp *DeSoMempool) isUnconnectedTxnInPool(hash *BlockHash) bool {
 
 func (mp *DeSoMempool) DumpTxnsToDB() {
 	// Dump all mempool txns into data_dir_path/temp_mempool_dump.
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
 	err := mp.OpenTempDBAndDumpTxns()
 	if err != nil {
 		glog.Infof("DumpTxnsToDB: Problem opening temp db / dumping mempool txns: %v", err)

--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -2360,6 +2360,8 @@ func (mp *DeSoMempool) StartMempoolDBDumper() {
 }
 
 func (mp *DeSoMempool) LoadTxnsFromDB() {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
 	glog.Infof("LoadTxnsFromDB: Loading mempool txns from db because --load_mempool_txns_from_db was set")
 	startTime := time.Now()
 

--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -2348,7 +2348,7 @@ func (mp *DeSoMempool) StartMempoolDBDumper() {
 				glog.Info("StartMempoolDBDumper: Waking up! Dumping txns now...")
 
 				// Dump the txns and time it.
-				// mp.DumpTxnsToDB()
+				mp.DumpTxnsToDB()
 
 			case <-mp.quit:
 				break out

--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -757,8 +757,6 @@ func MakeDirIfNonExistent(filePath string) error {
 }
 
 func (mp *DeSoMempool) OpenTempDBAndDumpTxns() error {
-	mp.mtx.Lock()
-	defer mp.mtx.Unlock()
 	blockHeight := uint64(mp.bc.blockTip().Height + 1)
 	allTxns := mp.readOnlyUniversalTransactionList
 
@@ -2350,7 +2348,7 @@ func (mp *DeSoMempool) StartMempoolDBDumper() {
 				glog.Info("StartMempoolDBDumper: Waking up! Dumping txns now...")
 
 				// Dump the txns and time it.
-				mp.DumpTxnsToDB()
+				// mp.DumpTxnsToDB()
 
 			case <-mp.quit:
 				break out
@@ -2360,8 +2358,6 @@ func (mp *DeSoMempool) StartMempoolDBDumper() {
 }
 
 func (mp *DeSoMempool) LoadTxnsFromDB() {
-	mp.mtx.Lock()
-	defer mp.mtx.Unlock()
 	glog.Infof("LoadTxnsFromDB: Loading mempool txns from db because --load_mempool_txns_from_db was set")
 	startTime := time.Now()
 


### PR DESCRIPTION
After some investigation I found that a single test was causing a leaking concurrent process that was having side-effects on subsequent tests. The test that triggers the problem is [TestBitcoinExchange](https://github.com/deso-protocol/core/blob/v2.2.5/lib/block_view_bitcoin_test.go#L215) which runs very early in the test suite. 

The underlying problem was the test is creating a new memepool instance in order to dump transactions to a tmp directory, which [triggers a process to run every 30 seconds to dump transactions](https://github.com/deso-protocol/core/blob/v2.2.5/lib/mempool.go#L2340). None of the tests actually need this process to be running, it's just an unwanted side effect of creating a mempool and passing in a non-empty value for the temp directory.

I initially attempted to fix this using a mutex lock with the [existing mtx prop](https://github.com/deso-protocol/core/blob/v2.2.5/lib/mempool.go#L171) on the memepool instance and guarding the [db dump function](https://github.com/deso-protocol/core/blob/v2.2.5/lib/mempool.go#L759). It did not resolve the issue unfortunately. 

The fix I've landed on here is to omit passing the tmp dir when creating the memepool and then manually load transactions instead of relying on the internal implementation which [triggers the unwanted process](https://github.com/deso-protocol/core/blob/v2.2.5/lib/mempool.go#L2457). 

Note that this issue fixes the test suite. I did some investigation into datadog production logs to see if this is also a problem for the application environment but this error seems to never happen in production. This is the error for reference:
```sh
I0427 08:11:44.803674    3522 mempool.go:707] DumpTxnsToDB: Problem opening temp db / dumping mempool txns: OpenTempDBAndDumpTxns: Could not open temp db to dump mempool: Cannot acquire directory lock on "/tmp/temp_mempool_dump".  Another process is using this Badger database. error: resource temporarily unavailable
```