### PR TITLE
Update Minor Error Message in blockchain.go

### DIFF
--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -4157,7 +4157,7 @@ func (bc *Blockchain) CreateUpdateNFTTxn(
 	// We want our transaction to have at least one input, even if it all
 	// goes to change. This ensures that the transaction will not be "replayable."
 	if len(txn.TxInputs) == 0 {
-		return nil, 0, 0, 0, fmt.Errorf("CreateUpdateNFTTxn: AcceptNFTBid txn " +
+		return nil, 0, 0, 0, fmt.Errorf("CreateUpdateNFTTxn: CreateUpdateNFT txn " +
 			"must have at least one input but had zero inputs " +
 			"instead. Try increasing the fee rate.")
 	}


### PR DESCRIPTION
Fixing minor copy/paste error in an error message for CreateUpdateNFTTxn. It was copied from a similar error for CreateAcceptNFTBidTxn.