### PR TITLE
NFTz node url update

### DIFF
--- a/lib/nodes.go
+++ b/lib/nodes.go
@@ -82,7 +82,7 @@ var NODES = map[uint64]DeSoNode{
 	},
 	12: {
 		Name:  "NFTz",
-		URL:   "https://nftz.zone",
+		URL:   "https://nftz.me",
 		Owner: "mvanhalen",
 	},
 	13: {


### PR DESCRIPTION
Updated nftz.zone to nftz.me to our main url.