### PR TITLE
validate association type and value does not contain null terminator

### DIFF
--- a/lib/block_view_association.go
+++ b/lib/block_view_association.go
@@ -492,6 +492,20 @@ func isValidAssociationValue(associationValue []byte) error {
 	return nil
 }
 
+func (bav *UtxoView) isValidAppPublicKey(appPublicKey *PublicKey) error {
+	// Validate AppPKID.
+	if appPublicKey == nil {
+		return RuleErrorAssociationInvalidApp
+	}
+	if !appPublicKey.IsZeroPublicKey() {
+		appPKIDEntry := bav.GetPKIDForPublicKey(appPublicKey.ToBytes())
+		if appPKIDEntry == nil || appPKIDEntry.isDeleted {
+			return RuleErrorAssociationInvalidApp
+		}
+	}
+	return nil
+}
+
 func (bav *UtxoView) IsValidCreateUserAssociationMetadata(transactorPK []byte, metadata *CreateUserAssociationMetadata) error {
 	// Returns an error if the input metadata is invalid. Otherwise, returns nil.
 
@@ -514,14 +528,8 @@ func (bav *UtxoView) IsValidCreateUserAssociationMetadata(transactorPK []byte, m
 	}
 
 	// Validate AppPKID.
-	if metadata.AppPublicKey == nil {
+	if err := bav.isValidAppPublicKey(metadata.AppPublicKey); err != nil {
 		return RuleErrorAssociationInvalidApp
-	}
-	if !metadata.AppPublicKey.IsZeroPublicKey() {
-		appPKIDEntry := bav.GetPKIDForPublicKey(metadata.AppPublicKey.ToBytes())
-		if appPKIDEntry == nil || appPKIDEntry.isDeleted {
-			return RuleErrorAssociationInvalidApp
-		}
 	}
 
 	// Validate AssociationType.
@@ -590,14 +598,8 @@ func (bav *UtxoView) IsValidCreatePostAssociationMetadata(transactorPK []byte, m
 	}
 
 	// Validate AppPKID.
-	if metadata.AppPublicKey == nil {
+	if err := bav.isValidAppPublicKey(metadata.AppPublicKey); err != nil {
 		return RuleErrorAssociationInvalidApp
-	}
-	if !metadata.AppPublicKey.IsZeroPublicKey() {
-		appPKIDEntry := bav.GetPKIDForPublicKey(metadata.AppPublicKey.ToBytes())
-		if appPKIDEntry == nil || appPKIDEntry.isDeleted {
-			return RuleErrorAssociationInvalidApp
-		}
 	}
 
 	// Validate AssociationType.

--- a/lib/block_view_association.go
+++ b/lib/block_view_association.go
@@ -473,6 +473,25 @@ func (bav *UtxoView) _disconnectDeletePostAssociation(
 // ## VALIDATIONS
 // ###########################
 
+func isValidAssociationType(associationType []byte) error {
+	if len(associationType) == 0 ||
+		len(associationType) > MaxAssociationTypeByteLength ||
+		bytes.HasPrefix(associationType, []byte(AssociationTypeReservedPrefix)) ||
+		bytes.IndexByte(associationType, AssociationNullTerminator) != -1 {
+		return RuleErrorAssociationInvalidType
+	}
+	return nil
+}
+
+func isValidAssociationValue(associationValue []byte) error {
+	if len(associationValue) == 0 ||
+		len(associationValue) > MaxAssociationValueByteLength ||
+		bytes.IndexByte(associationValue, AssociationNullTerminator) != -1 {
+		return RuleErrorAssociationInvalidValue
+	}
+	return nil
+}
+
 func (bav *UtxoView) IsValidCreateUserAssociationMetadata(transactorPK []byte, metadata *CreateUserAssociationMetadata) error {
 	// Returns an error if the input metadata is invalid. Otherwise, returns nil.
 
@@ -506,15 +525,12 @@ func (bav *UtxoView) IsValidCreateUserAssociationMetadata(transactorPK []byte, m
 	}
 
 	// Validate AssociationType.
-	if len(metadata.AssociationType) == 0 ||
-		len(metadata.AssociationType) > MaxAssociationTypeByteLength ||
-		bytes.HasPrefix(metadata.AssociationType, []byte(AssociationTypeReservedPrefix)) {
+	if err := isValidAssociationType(metadata.AssociationType); err != nil {
 		return RuleErrorAssociationInvalidType
 	}
 
 	// Validate AssociationValue.
-	if len(metadata.AssociationValue) == 0 ||
-		len(metadata.AssociationValue) > MaxAssociationValueByteLength {
+	if err := isValidAssociationValue(metadata.AssociationValue); err != nil {
 		return RuleErrorAssociationInvalidValue
 	}
 	return nil
@@ -585,15 +601,12 @@ func (bav *UtxoView) IsValidCreatePostAssociationMetadata(transactorPK []byte, m
 	}
 
 	// Validate AssociationType.
-	if len(metadata.AssociationType) == 0 ||
-		len(metadata.AssociationType) > MaxAssociationTypeByteLength ||
-		bytes.HasPrefix(metadata.AssociationType, []byte(AssociationTypeReservedPrefix)) {
+	if err := isValidAssociationType(metadata.AssociationType); err != nil {
 		return RuleErrorAssociationInvalidType
 	}
 
 	// Validate AssociationValue.
-	if len(metadata.AssociationValue) == 0 ||
-		len(metadata.AssociationValue) > MaxAssociationValueByteLength {
+	if err := isValidAssociationValue(metadata.AssociationValue); err != nil {
 		return RuleErrorAssociationInvalidValue
 	}
 	return nil

--- a/lib/block_view_association.go
+++ b/lib/block_view_association.go
@@ -498,10 +498,18 @@ func (bav *UtxoView) isValidAppPublicKey(appPublicKey *PublicKey) error {
 		return RuleErrorAssociationInvalidApp
 	}
 	if !appPublicKey.IsZeroPublicKey() {
-		appPKIDEntry := bav.GetPKIDForPublicKey(appPublicKey.ToBytes())
-		if appPKIDEntry == nil || appPKIDEntry.isDeleted {
-			return RuleErrorAssociationInvalidApp
-		}
+		return bav.existsAssociationPublicKeyBytes(appPublicKey.ToBytes())
+	}
+	return nil
+}
+
+func (bav *UtxoView) existsAssociationPublicKeyBytes(publicKey []byte) error {
+	if publicKey == nil {
+		return errors.New("public key provided is nil")
+	}
+	pkidEntry := bav.GetPKIDForPublicKey(publicKey)
+	if pkidEntry == nil || pkidEntry.isDeleted {
+		return errors.New("pkid entry not found")
 	}
 	return nil
 }
@@ -510,11 +518,7 @@ func (bav *UtxoView) IsValidCreateUserAssociationMetadata(transactorPK []byte, m
 	// Returns an error if the input metadata is invalid. Otherwise, returns nil.
 
 	// Validate TransactorPKID.
-	if transactorPK == nil {
-		return RuleErrorAssociationInvalidTransactor // This should never happen.
-	}
-	transactorPKIDEntry := bav.GetPKIDForPublicKey(transactorPK)
-	if transactorPKIDEntry == nil || transactorPKIDEntry.isDeleted {
+	if err := bav.existsAssociationPublicKeyBytes(transactorPK); err != nil {
 		return RuleErrorAssociationInvalidTransactor
 	}
 
@@ -522,8 +526,7 @@ func (bav *UtxoView) IsValidCreateUserAssociationMetadata(transactorPK []byte, m
 	if metadata.TargetUserPublicKey == nil {
 		return RuleErrorUserAssociationInvalidTargetUser
 	}
-	targetUserPKIDEntry := bav.GetPKIDForPublicKey(metadata.TargetUserPublicKey.ToBytes())
-	if targetUserPKIDEntry == nil || targetUserPKIDEntry.isDeleted {
+	if err := bav.existsAssociationPublicKeyBytes(metadata.TargetUserPublicKey.ToBytes()); err != nil {
 		return RuleErrorUserAssociationInvalidTargetUser
 	}
 
@@ -580,11 +583,7 @@ func (bav *UtxoView) IsValidCreatePostAssociationMetadata(transactorPK []byte, m
 	// Returns an error if the input metadata is invalid. Otherwise, returns nil.
 
 	// Validate TransactorPKID.
-	if transactorPK == nil {
-		return RuleErrorAssociationInvalidTransactor // This should never happen.
-	}
-	transactorPKIDEntry := bav.GetPKIDForPublicKey(transactorPK)
-	if transactorPKIDEntry == nil || transactorPKIDEntry.isDeleted {
+	if err := bav.existsAssociationPublicKeyBytes(transactorPK); err != nil {
 		return RuleErrorAssociationInvalidTransactor
 	}
 

--- a/lib/block_view_association_test.go
+++ b/lib/block_view_association_test.go
@@ -193,6 +193,20 @@ func _testAssociations(t *testing.T, flushToDB bool) {
 		require.Contains(t, err.Error(), RuleErrorAssociationInvalidType)
 	}
 	{
+		// RuleErrorAssociationInvalidType: AssociationType contains null terminator byte
+		createUserAssociationMetadata = &CreateUserAssociationMetadata{
+			TargetUserPublicKey: NewPublicKey(m1PkBytes),
+			AppPublicKey:        &ZeroPublicKey,
+			AssociationType:     append([]byte("ENDORSEMENT"), AssociationNullTerminator),
+			AssociationValue:    []byte("SQL"),
+		}
+		_, _, _, err = _submitAssociationTxn(
+			testMeta, m0Pub, m0Priv, MsgDeSoTxn{TxnMeta: createUserAssociationMetadata}, flushToDB,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), RuleErrorAssociationInvalidType)
+	}
+	{
 		// RuleErrorAssociationTypeInvalidValue: AssociationValue is empty
 		createUserAssociationMetadata = &CreateUserAssociationMetadata{
 			TargetUserPublicKey: NewPublicKey(m1PkBytes),
@@ -219,6 +233,20 @@ func _testAssociations(t *testing.T, flushToDB bool) {
 			AppPublicKey:        &ZeroPublicKey,
 			AssociationType:     []byte("ENDORSEMENT"),
 			AssociationValue:    associationValue,
+		}
+		_, _, _, err = _submitAssociationTxn(
+			testMeta, m0Pub, m0Priv, MsgDeSoTxn{TxnMeta: createUserAssociationMetadata}, flushToDB,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), RuleErrorAssociationInvalidValue)
+	}
+	{
+		// RuleErrorAssociationInvalidValue: AssociationValue contains null terminator byte
+		createUserAssociationMetadata = &CreateUserAssociationMetadata{
+			TargetUserPublicKey: NewPublicKey(m1PkBytes),
+			AppPublicKey:        &ZeroPublicKey,
+			AssociationType:     []byte("ENDORSEMENT"),
+			AssociationValue:    append([]byte("SQL"), AssociationNullTerminator),
 		}
 		_, _, _, err = _submitAssociationTxn(
 			testMeta, m0Pub, m0Priv, MsgDeSoTxn{TxnMeta: createUserAssociationMetadata}, flushToDB,
@@ -475,6 +503,20 @@ func _testAssociations(t *testing.T, flushToDB bool) {
 		require.Contains(t, err.Error(), RuleErrorAssociationInvalidType)
 	}
 	{
+		// RuleErrorAssociationInvalidType: AssociationType contains null terminator byte
+		createPostAssociationMetadata = &CreatePostAssociationMetadata{
+			PostHash:         postHash,
+			AppPublicKey:     &ZeroPublicKey,
+			AssociationType:  append([]byte("REACTION"), AssociationNullTerminator),
+			AssociationValue: []byte("HEART"),
+		}
+		_, _, _, err = _submitAssociationTxn(
+			testMeta, m0Pub, m0Priv, MsgDeSoTxn{TxnMeta: createPostAssociationMetadata}, flushToDB,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), RuleErrorAssociationInvalidType)
+	}
+	{
 		// RuleErrorAssociationTypeInvalidValue: AssociationValue is empty
 		createPostAssociationMetadata = &CreatePostAssociationMetadata{
 			PostHash:         postHash,
@@ -501,6 +543,20 @@ func _testAssociations(t *testing.T, flushToDB bool) {
 			AppPublicKey:     &ZeroPublicKey,
 			AssociationType:  []byte("REACTION"),
 			AssociationValue: associationValue,
+		}
+		_, _, _, err = _submitAssociationTxn(
+			testMeta, m0Pub, m0Priv, MsgDeSoTxn{TxnMeta: createPostAssociationMetadata}, flushToDB,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), RuleErrorAssociationInvalidValue)
+	}
+	{
+		// RuleErrorAssociationInvalidValue: AssociationValue contains null terminator byte
+		createPostAssociationMetadata = &CreatePostAssociationMetadata{
+			PostHash:         postHash,
+			AppPublicKey:     &ZeroPublicKey,
+			AssociationType:  []byte("REACTION"),
+			AssociationValue: append([]byte("HEART"), AssociationNullTerminator),
 		}
 		_, _, _, err = _submitAssociationTxn(
 			testMeta, m0Pub, m0Priv, MsgDeSoTxn{TxnMeta: createPostAssociationMetadata}, flushToDB,

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -1270,3 +1270,4 @@ const (
 const MaxAssociationTypeByteLength int = 64
 const MaxAssociationValueByteLength int = 256
 const AssociationTypeReservedPrefix = "DESO"
+const AssociationNullTerminator = byte(0)

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -8383,9 +8383,9 @@ func DBKeyForUserAssociationByTransactor(associationEntry *UserAssociationEntry)
 	key = append(key, Prefixes.PrefixUserAssociationByTransactor...)
 	key = append(key, associationEntry.TransactorPKID.ToBytes()...)
 	key = append(key, bytes.ToLower(associationEntry.AssociationType)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
-	key = append(key, []byte(associationEntry.AssociationValue)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
+	key = append(key, associationEntry.AssociationValue...)
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 	key = append(key, associationEntry.TargetUserPKID.ToBytes()...)
 	key = append(key, associationEntry.AppPKID.ToBytes()...)
 	return key
@@ -8397,9 +8397,9 @@ func DBKeyForUserAssociationByTargetUser(associationEntry *UserAssociationEntry)
 	key = append(key, Prefixes.PrefixUserAssociationByTargetUser...)
 	key = append(key, associationEntry.TargetUserPKID.ToBytes()...)
 	key = append(key, bytes.ToLower(associationEntry.AssociationType)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
-	key = append(key, []byte(associationEntry.AssociationValue)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
+	key = append(key, associationEntry.AssociationValue...)
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 	key = append(key, associationEntry.TransactorPKID.ToBytes()...)
 	key = append(key, associationEntry.AppPKID.ToBytes()...)
 	return key
@@ -8412,9 +8412,9 @@ func DBKeyForUserAssociationByUsers(associationEntry *UserAssociationEntry) []by
 	key = append(key, associationEntry.TransactorPKID.ToBytes()...)
 	key = append(key, associationEntry.TargetUserPKID.ToBytes()...)
 	key = append(key, bytes.ToLower(associationEntry.AssociationType)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
-	key = append(key, []byte(associationEntry.AssociationValue)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
+	key = append(key, associationEntry.AssociationValue...)
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 	key = append(key, associationEntry.AppPKID.ToBytes()...)
 	return key
 }
@@ -8449,9 +8449,9 @@ func DBKeyForPostAssociationByTransactor(associationEntry *PostAssociationEntry)
 	key = append(key, Prefixes.PrefixPostAssociationByTransactor...)
 	key = append(key, associationEntry.TransactorPKID.ToBytes()...)
 	key = append(key, bytes.ToLower(associationEntry.AssociationType)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
-	key = append(key, []byte(associationEntry.AssociationValue)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
+	key = append(key, associationEntry.AssociationValue...)
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 	key = append(key, associationEntry.PostHash.ToBytes()...)
 	key = append(key, associationEntry.AppPKID.ToBytes()...)
 	return key
@@ -8463,9 +8463,9 @@ func DBKeyForPostAssociationByPost(associationEntry *PostAssociationEntry) []byt
 	key = append(key, Prefixes.PrefixPostAssociationByPost...)
 	key = append(key, associationEntry.PostHash.ToBytes()...)
 	key = append(key, bytes.ToLower(associationEntry.AssociationType)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
-	key = append(key, []byte(associationEntry.AssociationValue)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
+	key = append(key, associationEntry.AssociationValue...)
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 	key = append(key, associationEntry.TransactorPKID.ToBytes()...)
 	key = append(key, associationEntry.AppPKID.ToBytes()...)
 	return key
@@ -8476,9 +8476,9 @@ func DBKeyForPostAssociationByType(associationEntry *PostAssociationEntry) []byt
 	var key []byte
 	key = append(key, Prefixes.PrefixPostAssociationByType...)
 	key = append(key, bytes.ToLower(associationEntry.AssociationType)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
-	key = append(key, []byte(associationEntry.AssociationValue)...)
-	key = append(key, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
+	key = append(key, associationEntry.AssociationValue...)
+	key = append(key, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 	key = append(key, associationEntry.PostHash.ToBytes()...)
 	key = append(key, associationEntry.TransactorPKID.ToBytes()...)
 	key = append(key, associationEntry.AppPKID.ToBytes()...)
@@ -8676,7 +8676,7 @@ func DBGetUserAssociationIdsByAttributes(
 	// AssociationType
 	if len(associationQuery.AssociationType) > 0 {
 		keyPrefix = append(keyPrefix, bytes.ToLower(associationQuery.AssociationType)...)
-		keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
+		keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
 	} else if len(associationQuery.AssociationValue) > 0 || len(associationQuery.AssociationValuePrefix) > 0 {
 		// AssociationType == "", (AssociationValue != "" || AssociationValuePrefix != "")
 		return nil, nil, errors.New("DBGetUserAssociationIdsByAttributes: invalid query params: missing AssociationType")
@@ -8687,7 +8687,7 @@ func DBGetUserAssociationIdsByAttributes(
 	// AssociationValue
 	if len(associationQuery.AssociationValue) > 0 {
 		keyPrefix = append(keyPrefix, associationQuery.AssociationValue...)
-		keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+		keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 	} else if len(associationQuery.AssociationValuePrefix) > 0 {
 		keyPrefix = append(keyPrefix, associationQuery.AssociationValuePrefix...)
 	}
@@ -8799,7 +8799,7 @@ func DBGetPostAssociationIdsByAttributes(
 		// AssociationType
 		if len(associationQuery.AssociationType) > 0 {
 			keyPrefix = append(keyPrefix, bytes.ToLower(associationQuery.AssociationType)...)
-			keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
+			keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
 		} else if len(associationQuery.AssociationValue) > 0 ||
 			len(associationQuery.AssociationValuePrefix) > 0 ||
 			associationQuery.PostHash != nil {
@@ -8812,7 +8812,7 @@ func DBGetPostAssociationIdsByAttributes(
 		// AssociationValue
 		if len(associationQuery.AssociationValue) > 0 {
 			keyPrefix = append(keyPrefix, associationQuery.AssociationValue...)
-			keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+			keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 		} else if associationQuery.PostHash != nil {
 			// AssociationValue == "", PostHash != nil
 			return nil, nil, errors.New("DBGetPostAssociationIdsByAttributes: invalid query params: missing AssociationValue")
@@ -8837,7 +8837,7 @@ func DBGetPostAssociationIdsByAttributes(
 		// AssociationType
 		if len(associationQuery.AssociationType) > 0 {
 			keyPrefix = append(keyPrefix, bytes.ToLower(associationQuery.AssociationType)...)
-			keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
+			keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
 		} else if len(associationQuery.AssociationValue) > 0 || len(associationQuery.AssociationValuePrefix) > 0 {
 			// AssociationType == "", (AssociationValue != "" || AssociationValuePrefix != "")
 			return nil, nil, errors.New("DBGetPostAssociationIdsByAttributes: invalid query params: missing AssociationType")
@@ -8848,7 +8848,7 @@ func DBGetPostAssociationIdsByAttributes(
 		// AssociationValue
 		if len(associationQuery.AssociationValue) > 0 {
 			keyPrefix = append(keyPrefix, associationQuery.AssociationValue...)
-			keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+			keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 		} else if len(associationQuery.AssociationValuePrefix) > 0 {
 			keyPrefix = append(keyPrefix, []byte(associationQuery.AssociationValuePrefix)...)
 		}
@@ -8862,7 +8862,7 @@ func DBGetPostAssociationIdsByAttributes(
 		// AssociationType
 		if len(associationQuery.AssociationType) > 0 {
 			keyPrefix = append(keyPrefix, bytes.ToLower(associationQuery.AssociationType)...)
-			keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationType which can vary in length
+			keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationType which can vary in length
 		} else if len(associationQuery.AssociationValue) > 0 || len(associationQuery.AssociationValuePrefix) > 0 {
 			// AssociationType == "", (AssociationValue != "" || AssociationValuePrefix != "")
 			return nil, nil, errors.New("DBGetPostAssociationIdsByAttributes: invalid query params: missing AssociationType")
@@ -8873,7 +8873,7 @@ func DBGetPostAssociationIdsByAttributes(
 		// AssociationValue
 		if len(associationQuery.AssociationValue) > 0 {
 			keyPrefix = append(keyPrefix, associationQuery.AssociationValue...)
-			keyPrefix = append(keyPrefix, []byte{0}...) // Null terminator byte for AssociationValue which can vary in length
+			keyPrefix = append(keyPrefix, AssociationNullTerminator) // Null terminator byte for AssociationValue which can vary in length
 		} else if len(associationQuery.AssociationValuePrefix) > 0 {
 			keyPrefix = append(keyPrefix, associationQuery.AssociationValuePrefix...)
 		}


### PR DESCRIPTION
- add validation that association types and association value do not contain the null terminator byte
- replace occurrences of []byte{0} as null terminator byte with the const `AssociationNullTerminator` which is a `byte(0)`
- refactor some logic in `isCreateValidUserAssociationMetadata` and `isValidPostAssociationMetadata` to deduplicate code