### PR TITLE
Mf/remove jailed stake from global active stake

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -118,8 +118,8 @@ type UtxoView struct {
 	// Validator mappings
 	ValidatorPKIDToValidatorEntry map[PKID]*ValidatorEntry
 
-	// Global stake across all validators
-	GlobalStakeAmountNanos *uint256.Int
+	// Global active stake across all validators
+	GlobalActiveStakeAmountNanos *uint256.Int
 
 	// Stake mappings
 	StakeMapKeyToStakeEntry map[StakeMapKey]*StakeEntry
@@ -222,10 +222,10 @@ func (bav *UtxoView) _ResetViewMappingsAfterFlush() {
 	// ValidatorEntries
 	bav.ValidatorPKIDToValidatorEntry = make(map[PKID]*ValidatorEntry)
 
-	// Global stake across validators. We deliberately want this to initialize to nil and not zero
-	// since a zero value will overwrite an existing GlobalStakeAmountNanos value in the db, whereas
-	// a nil GlobalStakeAmountNanos value signifies that this value was never set.
-	bav.GlobalStakeAmountNanos = nil
+	// Global active stake across validators. We deliberately want this to initialize to nil and not zero
+	// since a zero value will overwrite an existing GlobalActiveStakeAmountNanos value in the db, whereas
+	// a nil GlobalActiveStakeAmountNanos value signifies that this value was never set.
+	bav.GlobalActiveStakeAmountNanos = nil
 
 	// StakeEntries
 	bav.StakeMapKeyToStakeEntry = make(map[StakeMapKey]*StakeEntry)
@@ -493,9 +493,9 @@ func (bav *UtxoView) CopyUtxoView() (*UtxoView, error) {
 		newView.ValidatorPKIDToValidatorEntry[entryKey] = entry.Copy()
 	}
 
-	// Copy the GlobalStakeAmountNanos.
-	if bav.GlobalStakeAmountNanos != nil {
-		newView.GlobalStakeAmountNanos = bav.GlobalStakeAmountNanos.Clone()
+	// Copy the GlobalActiveStakeAmountNanos.
+	if bav.GlobalActiveStakeAmountNanos != nil {
+		newView.GlobalActiveStakeAmountNanos = bav.GlobalActiveStakeAmountNanos.Clone()
 	}
 
 	// Copy the StakeEntries

--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -118,7 +118,7 @@ type UtxoView struct {
 	// Validator mappings
 	ValidatorPKIDToValidatorEntry map[PKID]*ValidatorEntry
 
-	// Global active stake across all validators
+	// The global active stake is the sum of all stake across validators who have Status = Active.
 	GlobalActiveStakeAmountNanos *uint256.Int
 
 	// Stake mappings

--- a/lib/block_view_flush.go
+++ b/lib/block_view_flush.go
@@ -143,7 +143,7 @@ func (bav *UtxoView) FlushToDbWithTxn(txn *badger.Txn, blockHeight uint64) error
 	if err := bav._flushValidatorEntriesToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}
-	if err := bav._flushGlobalStakeAmountNanosToDbWithTxn(txn, blockHeight); err != nil {
+	if err := bav._flushGlobalActiveStakeAmountNanosToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}
 	if err := bav._flushStakeEntriesToDbWithTxn(txn, blockHeight); err != nil {

--- a/lib/block_view_stake.go
+++ b/lib/block_view_stake.go
@@ -1341,8 +1341,8 @@ func (bav *UtxoView) _disconnectStake(
 		bav._setStakeEntryMappings(operationData.PrevStakeEntries[0])
 	}
 
-	// Restore the PrevGlobalActiveStakeAmountNanos if the PrevValidatorEntry was active.
-	if prevValidatorEntry.Status() == ValidatorStatusActive {
+	// Restore the PrevGlobalActiveStakeAmountNanos, if exists.
+	if operationData.PrevGlobalActiveStakeAmountNanos != nil {
 		bav._setGlobalActiveStakeAmountNanos(operationData.PrevGlobalActiveStakeAmountNanos)
 	}
 
@@ -1620,8 +1620,8 @@ func (bav *UtxoView) _disconnectUnstake(
 	}
 	bav._setStakeEntryMappings(operationData.PrevStakeEntries[0])
 
-	// Restore the PrevGlobalActiveStakeAmountNanos if the PrevValidatorEntry was active.
-	if prevValidatorEntry.Status() == ValidatorStatusActive {
+	// Restore the PrevGlobalActiveStakeAmountNanos, if exists.
+	if operationData.PrevGlobalActiveStakeAmountNanos != nil {
 		bav._setGlobalActiveStakeAmountNanos(operationData.PrevGlobalActiveStakeAmountNanos)
 	}
 
@@ -2049,6 +2049,8 @@ func (bav *UtxoView) SanityCheckStakeTxn(
 		if !globalActiveStakeAmountNanosIncrease.Eq(amountNanos) {
 			return errors.New("SanityCheckStakeTxn: GlobalActiveStakeAmountNanos increase does not match")
 		}
+	} else if utxoOp.PrevGlobalActiveStakeAmountNanos != nil {
+		return errors.New("SanityCheckStakeTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator")
 	}
 
 	// Validate TransactorBalance decrease.
@@ -2165,6 +2167,8 @@ func (bav *UtxoView) SanityCheckUnstakeTxn(transactorPKID *PKID, utxoOp *UtxoOpe
 		if !globalActiveStakeAmountNanosDecrease.Eq(amountNanos) {
 			return errors.New("SanityCheckUnstakeTxn: GlobalActiveStakeAmountNanos decrease does not match")
 		}
+	} else if utxoOp.PrevGlobalActiveStakeAmountNanos != nil {
+		return errors.New("SanityCheckUnstakeTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator")
 	}
 
 	return nil

--- a/lib/block_view_stake.go
+++ b/lib/block_view_stake.go
@@ -2050,7 +2050,7 @@ func (bav *UtxoView) SanityCheckStakeTxn(
 			return errors.New("SanityCheckStakeTxn: GlobalActiveStakeAmountNanos increase does not match")
 		}
 	} else if utxoOp.PrevGlobalActiveStakeAmountNanos != nil {
-		return errors.New("SanityCheckStakeTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator")
+		return errors.New("SanityCheckStakeTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator, this should never happen")
 	}
 
 	// Validate TransactorBalance decrease.
@@ -2168,7 +2168,7 @@ func (bav *UtxoView) SanityCheckUnstakeTxn(transactorPKID *PKID, utxoOp *UtxoOpe
 			return errors.New("SanityCheckUnstakeTxn: GlobalActiveStakeAmountNanos decrease does not match")
 		}
 	} else if utxoOp.PrevGlobalActiveStakeAmountNanos != nil {
-		return errors.New("SanityCheckUnstakeTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator")
+		return errors.New("SanityCheckUnstakeTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator, this should never happen")
 	}
 
 	return nil

--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -1877,9 +1877,7 @@ func (op *UtxoOperation) RawDecodeWithoutMetadata(blockHeight uint64, rr *bytes.
 		}
 
 		// PrevGlobalActiveStakeAmountNanos
-		if prevGlobalActiveStakeAmountNanos, err := VariableDecodeUint256(rr); err == nil {
-			op.PrevGlobalActiveStakeAmountNanos = prevGlobalActiveStakeAmountNanos
-		} else {
+		if op.PrevGlobalActiveStakeAmountNanos, err = VariableDecodeUint256(rr); err != nil {
 			return errors.Wrapf(err, "UtxoOperation.Decode: Problem reading PrevGlobalActiveStakeAmountNanos: ")
 		}
 

--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -913,9 +913,9 @@ type UtxoOperation struct {
 	// register, unregister, stake, or unstake txn.
 	PrevValidatorEntry *ValidatorEntry
 
-	// PrevGlobalStakeAmountNanos is the previous GlobalStakeAmountNanos
+	// PrevGlobalActiveStakeAmountNanos is the previous GlobalActiveStakeAmountNanos
 	// prior to a stake or unstake operation txn.
-	PrevGlobalStakeAmountNanos *uint256.Int
+	PrevGlobalActiveStakeAmountNanos *uint256.Int
 
 	// PrevStakeEntries is a slice of StakeEntries prior to
 	// a register, unregister, stake, or unstake txn.
@@ -1245,8 +1245,8 @@ func (op *UtxoOperation) RawEncodeWithoutMetadata(blockHeight uint64, skipMetada
 		// PrevValidatorEntry
 		data = append(data, EncodeToBytes(blockHeight, op.PrevValidatorEntry, skipMetadata...)...)
 
-		// PrevGlobalStakeAmountNanos
-		data = append(data, VariableEncodeUint256(op.PrevGlobalStakeAmountNanos)...)
+		// PrevGlobalActiveStakeAmountNanos
+		data = append(data, VariableEncodeUint256(op.PrevGlobalActiveStakeAmountNanos)...)
 
 		// PrevStakeEntries
 		data = append(data, EncodeDeSoEncoderSlice(op.PrevStakeEntries, blockHeight, skipMetadata...)...)
@@ -1876,11 +1876,11 @@ func (op *UtxoOperation) RawDecodeWithoutMetadata(blockHeight uint64, rr *bytes.
 			return errors.Wrapf(err, "UtxoOperation.Decode: Problem reading PrevValidatorEntry: ")
 		}
 
-		// PrevGlobalStakeAmountNanos
-		if prevGlobalStakeAmountNanos, err := VariableDecodeUint256(rr); err == nil {
-			op.PrevGlobalStakeAmountNanos = prevGlobalStakeAmountNanos
+		// PrevGlobalActiveStakeAmountNanos
+		if prevGlobalActiveStakeAmountNanos, err := VariableDecodeUint256(rr); err == nil {
+			op.PrevGlobalActiveStakeAmountNanos = prevGlobalActiveStakeAmountNanos
 		} else {
-			return errors.Wrapf(err, "UtxoOperation.Decode: Problem reading PrevGlobalStakeAmountNanos: ")
+			return errors.Wrapf(err, "UtxoOperation.Decode: Problem reading PrevGlobalActiveStakeAmountNanos: ")
 		}
 
 		// PrevStakeEntries

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1414,8 +1414,8 @@ func (bav *UtxoView) _disconnectUnregisterAsValidator(
 		bav._setLockedStakeEntryMappings(prevLockedStakeEntry)
 	}
 
-	// Restore the PrevGlobalActiveStakeAmountNanos if the PrevValidatorEntry was active.
-	if prevValidatorEntry.Status() == ValidatorStatusActive {
+	// Restore the PrevGlobalActiveStakeAmountNanos, if exists.
+	if operationData.PrevGlobalActiveStakeAmountNanos != nil {
 		bav._setGlobalActiveStakeAmountNanos(operationData.PrevGlobalActiveStakeAmountNanos)
 	}
 
@@ -1787,6 +1787,8 @@ func (bav *UtxoView) SanityCheckUnregisterAsValidatorTxn(
 		if !globalActiveStakeAmountNanosDecrease.Eq(amountNanos) {
 			return errors.New("SanityCheckUnregisterAsValidatorTxn: GlobalActiveStakeAmountNanos decrease doesn't match")
 		}
+	} else if utxoOp.PrevGlobalActiveStakeAmountNanos != nil {
+		return errors.New("SanityCheckUnregisterAsValidatorTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator")
 	}
 
 	return nil

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1908,11 +1908,8 @@ func (bav *UtxoView) JailValidator(validatorEntry *ValidatorEntry) error {
 		return errors.Wrapf(err, "UtxoView.JailValidator: error retrieving CurrentEpochNumber: ")
 	}
 
-	// Set JailedAtEpochNumber = CurrentEpochNumber.
+	// Set ValidatorEntry.JailedAtEpochNumber to the CurrentEpochNumber.
 	validatorEntry.JailedAtEpochNumber = currentEpochNumber
-
-	// Store the updated ValidatorEntry.
-	bav._setValidatorEntryMappings(validatorEntry)
 
 	// Remove the validator's stake from the GlobalActiveStakeAmountNanos.
 	prevGlobalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
@@ -1925,6 +1922,11 @@ func (bav *UtxoView) JailValidator(validatorEntry *ValidatorEntry) error {
 	if err != nil {
 		return errors.Wrapf(err, "UtxoView.JailValidator: error calculating updated GlobalActiveStakeAmountNanos: ")
 	}
+
+	// Store the updated ValidatorEntry.
+	bav._setValidatorEntryMappings(validatorEntry)
+
+	// Store the updated GlobalActiveStakeAmountNanos.
 	bav._setGlobalActiveStakeAmountNanos(currentGlobalActiveStakeAmountNanos)
 
 	return nil

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1586,7 +1586,7 @@ func (bav *UtxoView) _disconnectUnjailValidator(
 	// Restore the PrevGlobalActiveStakeAmountNanos.
 	prevGlobalActiveStakeAmountNanos := operationData.PrevGlobalActiveStakeAmountNanos
 	if prevGlobalActiveStakeAmountNanos == nil {
-		return errors.New("_disconnectUnjailValidator: PrevGlobalActiveStakeAmountNanos is nil")
+		return errors.New("_disconnectUnjailValidator: PrevGlobalActiveStakeAmountNanos is nil, this should never happen")
 	}
 	bav._setGlobalActiveStakeAmountNanos(prevGlobalActiveStakeAmountNanos)
 

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -29,10 +29,6 @@ import (
 // validator was first jailed. A validator is jailed if they fail to participate in consensus by
 // either voting or proposing blocks for too long. A jailed validator is ineligible to receive
 // any block rewards and ineligible to elected leader.
-//
-// FIXME: In the future, when we flesh out the jail/unjail functionality, we will want to make it
-// so that the validator's stake is removed/added to GlobalStakeAmountNanos. See FIXME on
-// _connectUnjailValidator for more details.
 
 //
 // TYPES: ValidatorEntry
@@ -550,8 +546,8 @@ func DBKeyForValidatorByStake(validatorEntry *ValidatorEntry) []byte {
 	return key
 }
 
-func DBKeyForGlobalStakeAmountNanos() []byte {
-	return append([]byte{}, Prefixes.PrefixGlobalStakeAmountNanos...)
+func DBKeyForGlobalActiveStakeAmountNanos() []byte {
+	return append([]byte{}, Prefixes.PrefixGlobalActiveStakeAmountNanos...)
 }
 
 func DBGetValidatorByPKID(handle *badger.DB, snap *Snapshot, pkid *PKID) (*ValidatorEntry, error) {
@@ -630,36 +626,36 @@ func DBGetTopActiveValidatorsByStake(
 	return validatorEntries, nil
 }
 
-func DBGetGlobalStakeAmountNanos(handle *badger.DB, snap *Snapshot) (*uint256.Int, error) {
+func DBGetGlobalActiveStakeAmountNanos(handle *badger.DB, snap *Snapshot) (*uint256.Int, error) {
 	var ret *uint256.Int
 	err := handle.View(func(txn *badger.Txn) error {
 		var innerErr error
-		ret, innerErr = DBGetGlobalStakeAmountNanosWithTxn(txn, snap)
+		ret, innerErr = DBGetGlobalActiveStakeAmountNanosWithTxn(txn, snap)
 		return innerErr
 	})
 	return ret, err
 }
 
-func DBGetGlobalStakeAmountNanosWithTxn(txn *badger.Txn, snap *Snapshot) (*uint256.Int, error) {
+func DBGetGlobalActiveStakeAmountNanosWithTxn(txn *badger.Txn, snap *Snapshot) (*uint256.Int, error) {
 	// Retrieve from db.
-	key := DBKeyForGlobalStakeAmountNanos()
-	globalStakeAmountNanosBytes, err := DBGetWithTxn(txn, snap, key)
+	key := DBKeyForGlobalActiveStakeAmountNanos()
+	globalActiveStakeAmountNanosBytes, err := DBGetWithTxn(txn, snap, key)
 	if err != nil {
 		// We don't want to error if the key isn't found. Instead, return 0.
 		if err == badger.ErrKeyNotFound {
 			return uint256.NewInt(), nil
 		}
-		return nil, errors.Wrapf(err, "DBGetGlobalStakeAmountNanosWithTxn: problem retrieving value")
+		return nil, errors.Wrapf(err, "DBGetGlobalActiveStakeAmountNanosWithTxn: problem retrieving value")
 	}
 
 	// Decode from bytes.
-	var globalStakeAmountNanos *uint256.Int
-	rr := bytes.NewReader(globalStakeAmountNanosBytes)
-	globalStakeAmountNanos, err = VariableDecodeUint256(rr)
+	var globalActiveStakeAmountNanos *uint256.Int
+	rr := bytes.NewReader(globalActiveStakeAmountNanosBytes)
+	globalActiveStakeAmountNanos, err = VariableDecodeUint256(rr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "DBGetGlobalStakeAmountNanosWithTxn: problem decoding value")
+		return nil, errors.Wrapf(err, "DBGetGlobalActiveStakeAmountNanosWithTxn: problem decoding value")
 	}
-	return globalStakeAmountNanos, nil
+	return globalActiveStakeAmountNanos, nil
 }
 
 func DBPutValidatorWithTxn(
@@ -734,20 +730,20 @@ func DBDeleteValidatorWithTxn(txn *badger.Txn, snap *Snapshot, validatorPKID *PK
 	return nil
 }
 
-func DBPutGlobalStakeAmountNanosWithTxn(
+func DBPutGlobalActiveStakeAmountNanosWithTxn(
 	txn *badger.Txn,
 	snap *Snapshot,
-	globalStakeAmountNanos *uint256.Int,
+	globalActiveStakeAmountNanos *uint256.Int,
 	blockHeight uint64,
 ) error {
-	if globalStakeAmountNanos == nil {
+	if globalActiveStakeAmountNanos == nil {
 		// This should never happen but is a sanity check.
-		glog.Errorf("DBPutGlobalStakeAmountNanosWithTxn: called with nil GlobalStakeAmountNanos")
+		glog.Errorf("DBPutGlobalActiveStakeAmountNanosWithTxn: called with nil GlobalActiveStakeAmountNanos")
 		return nil
 	}
 
-	key := DBKeyForGlobalStakeAmountNanos()
-	return DBSetWithTxn(txn, snap, key, VariableEncodeUint256(globalStakeAmountNanos))
+	key := DBKeyForGlobalActiveStakeAmountNanos()
+	return DBSetWithTxn(txn, snap, key, VariableEncodeUint256(globalActiveStakeAmountNanos))
 }
 
 //
@@ -1310,31 +1306,35 @@ func (bav *UtxoView) _connectUnregisterAsValidator(
 		)
 	}
 
-	// Decrease the GlobalStakeAmountNanos by the amount that was unstaked.
-	// Fetch the existing GlobalStakeAmountNanos.
-	prevGlobalStakeAmountNanos, err := bav.GetGlobalStakeAmountNanos()
-	if err != nil {
-		return 0, 0, nil, errors.Wrapf(err, "_connectUnregisterAsValidator: error fetching GlobalStakeAmountNanos: ")
-	}
-	// Subtract the amount that was unstaked.
-	globalStakeAmountNanos, err := SafeUint256().Sub(
-		prevGlobalStakeAmountNanos, totalUnstakedAmountNanos,
-	)
-	if err != nil {
-		return 0, 0, nil, errors.Wrapf(
-			err, "_connectUnregisterAsValidator: error subtracting TotalUnstakedAmountNanos from GlobalStakeAmountNanos: ",
+	// If the validator was active, decrease the GlobalActiveStakeAmountNanos
+	// by the amount that was unstaked. Do nothing if the validator was jailed.
+	var prevGlobalActiveStakeAmountNanos *uint256.Int
+	if prevValidatorEntry.Status() == ValidatorStatusActive {
+		// Fetch the existing GlobalActiveStakeAmountNanos.
+		prevGlobalActiveStakeAmountNanos, err = bav.GetGlobalActiveStakeAmountNanos()
+		if err != nil {
+			return 0, 0, nil, errors.Wrapf(err, "_connectUnregisterAsValidator: error fetching GlobalActiveStakeAmountNanos: ")
+		}
+		// Subtract the amount that was unstaked.
+		globalActiveStakeAmountNanos, err := SafeUint256().Sub(
+			prevGlobalActiveStakeAmountNanos, totalUnstakedAmountNanos,
 		)
+		if err != nil {
+			return 0, 0, nil, errors.Wrapf(
+				err, "_connectUnregisterAsValidator: error subtracting TotalUnstakedAmountNanos from GlobalActiveStakeAmountNanos: ",
+			)
+		}
+		// Set the new GlobalActiveStakeAmountNanos.
+		bav._setGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos)
 	}
-	// Set the new GlobalStakeAmountNanos.
-	bav._setGlobalStakeAmountNanos(globalStakeAmountNanos)
 
 	// Create a UTXO operation.
 	utxoOpForTxn := &UtxoOperation{
-		Type:                       OperationTypeUnregisterAsValidator,
-		PrevValidatorEntry:         prevValidatorEntry,
-		PrevGlobalStakeAmountNanos: prevGlobalStakeAmountNanos,
-		PrevStakeEntries:           prevStakeEntries,
-		PrevLockedStakeEntries:     prevLockedStakeEntries,
+		Type:                             OperationTypeUnregisterAsValidator,
+		PrevValidatorEntry:               prevValidatorEntry,
+		PrevGlobalActiveStakeAmountNanos: prevGlobalActiveStakeAmountNanos,
+		PrevStakeEntries:                 prevStakeEntries,
+		PrevLockedStakeEntries:           prevLockedStakeEntries,
 	}
 	if err = bav.SanityCheckUnregisterAsValidatorTxn(transactorPKIDEntry.PKID, utxoOpForTxn, totalUnstakedAmountNanos); err != nil {
 		return 0, 0, nil, errors.Wrapf(err, "_connectUnregisterAsValidator: ")
@@ -1414,8 +1414,10 @@ func (bav *UtxoView) _disconnectUnregisterAsValidator(
 		bav._setLockedStakeEntryMappings(prevLockedStakeEntry)
 	}
 
-	// Restore the PrevGlobalStakeAmountNanos.
-	bav._setGlobalStakeAmountNanos(operationData.PrevGlobalStakeAmountNanos)
+	// Restore the PrevGlobalActiveStakeAmountNanos if the PrevValidatorEntry was active.
+	if prevValidatorEntry.Status() == ValidatorStatusActive {
+		bav._setGlobalActiveStakeAmountNanos(operationData.PrevGlobalActiveStakeAmountNanos)
+	}
 
 	// Disconnect the BasicTransfer.
 	return bav._disconnectBasicTransfer(
@@ -1423,10 +1425,6 @@ func (bav *UtxoView) _disconnectUnregisterAsValidator(
 	)
 }
 
-// FIXME: Currently, unjail does not re-add a validator's stake back to the GlobalStakeAmountNanos.
-// When we flesh out the logic for jail/unjail, we will want to make it so that the process that
-// jails a validator *removes* their stake from GlobalStakeAmountNanos, and the process that unjails,
-// i.e. this function, *re-adds* their stake back to GlobalStakeAmountNanos.
 func (bav *UtxoView) _connectUnjailValidator(
 	txn *MsgDeSoTxn,
 	txHash *BlockHash,
@@ -1514,10 +1512,24 @@ func (bav *UtxoView) _connectUnjailValidator(
 	// Set the CurrentValidatorEntry.
 	bav._setValidatorEntryMappings(currentValidatorEntry)
 
+	// Increase the GlobalActiveStakeAmountNanos.
+	prevGlobalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
+	if err != nil {
+		return 0, 0, nil, errors.Wrapf(err, "_connectUnjailValidator: error retrieving existing GlobalActiveStakeAmountNanos: ")
+	}
+	currentGlobalActiveStakeAmountNanos, err := SafeUint256().Add(
+		prevGlobalActiveStakeAmountNanos, currentValidatorEntry.TotalStakeAmountNanos,
+	)
+	if err != nil {
+		return 0, 0, nil, errors.Wrapf(err, "_connectUnjailValidator: error calculating updated GlobalActiveStakeAmountNanos ")
+	}
+	bav._setGlobalActiveStakeAmountNanos(currentGlobalActiveStakeAmountNanos)
+
 	// Add a UTXO operation
 	utxoOpsForTxn = append(utxoOpsForTxn, &UtxoOperation{
-		Type:               OperationTypeUnjailValidator,
-		PrevValidatorEntry: prevValidatorEntry,
+		Type:                             OperationTypeUnjailValidator,
+		PrevValidatorEntry:               prevValidatorEntry,
+		PrevGlobalActiveStakeAmountNanos: prevGlobalActiveStakeAmountNanos,
 	})
 	return totalInput, totalOutput, utxoOpsForTxn, nil
 }
@@ -1570,6 +1582,13 @@ func (bav *UtxoView) _disconnectUnjailValidator(
 		return errors.New("_disconnectUnjailValidator: PrevValidatorEntry is nil")
 	}
 	bav._setValidatorEntryMappings(prevValidatorEntry)
+
+	// Restore the PrevGlobalActiveStakeAmountNanos.
+	prevGlobalActiveStakeAmountNanos := operationData.PrevGlobalActiveStakeAmountNanos
+	if prevGlobalActiveStakeAmountNanos == nil {
+		return errors.New("_disconnectUnjailValidator: PrevGlobalActiveStakeAmountNanos is nil")
+	}
+	bav._setGlobalActiveStakeAmountNanos(prevGlobalActiveStakeAmountNanos)
 
 	// Disconnect the BasicTransfer.
 	return bav._disconnectBasicTransfer(
@@ -1751,21 +1770,25 @@ func (bav *UtxoView) SanityCheckUnregisterAsValidatorTxn(
 		return errors.New("SanityCheckUnregisterAsValidatorTxn: TotalUnstakedAmountNanos doesn't match")
 	}
 
-	// Sanity check that the GlobalStakeAmountNanos was decreased by amountNanos.
-	if utxoOp.PrevGlobalStakeAmountNanos == nil {
-		return errors.New("SanityCheckUnregisterAsValidatorTxn: nil PrevGlobalStakeAmountNanos provided")
+	// Sanity check that the GlobalActiveStakeAmountNanos was decreased
+	// by amountNanos if the PrevValidatorEntry was active.
+	if utxoOp.PrevValidatorEntry.Status() == ValidatorStatusActive {
+		if utxoOp.PrevGlobalActiveStakeAmountNanos == nil {
+			return errors.New("SanityCheckUnregisterAsValidatorTxn: nil PrevGlobalActiveStakeAmountNanos provided")
+		}
+		currentGlobalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
+		if err != nil {
+			return errors.Wrapf(err, "SanityCheckUnregisterAsValidatorTxn: error retrieving GlobalActiveStakeAmountNanos: ")
+		}
+		globalActiveStakeAmountNanosDecrease, err := SafeUint256().Sub(utxoOp.PrevGlobalActiveStakeAmountNanos, currentGlobalActiveStakeAmountNanos)
+		if err != nil {
+			return errors.Wrapf(err, "SanityCheckUnregisterAsValidatorTxn: error calculating GlobalActiveStakeAmountNanos decrease: ")
+		}
+		if !globalActiveStakeAmountNanosDecrease.Eq(amountNanos) {
+			return errors.New("SanityCheckUnregisterAsValidatorTxn: GlobalActiveStakeAmountNanos decrease doesn't match")
+		}
 	}
-	currentGlobalStakeAmountNanos, err := bav.GetGlobalStakeAmountNanos()
-	if err != nil {
-		return errors.Wrapf(err, "SanityCheckUnregisterAsValidatorTxn: error retrieving GlobalStakeAmountNanos: ")
-	}
-	globalStakeAmountNanosDecrease, err := SafeUint256().Sub(utxoOp.PrevGlobalStakeAmountNanos, currentGlobalStakeAmountNanos)
-	if err != nil {
-		return errors.Wrapf(err, "SanityCheckUnregisterAsValidatorTxn: error calculating GlobalStakeAmountNanos decrease: ")
-	}
-	if !globalStakeAmountNanosDecrease.Eq(amountNanos) {
-		return errors.New("SanityCheckUnregisterAsValidatorTxn: GlobalStakeAmountNanos decrease doesn't match")
-	}
+
 	return nil
 }
 
@@ -1860,22 +1883,51 @@ func (bav *UtxoView) GetTopActiveValidatorsByStake(limit int) ([]*ValidatorEntry
 	return validatorEntries[0:upperBound], nil
 }
 
-func (bav *UtxoView) GetGlobalStakeAmountNanos() (*uint256.Int, error) {
-	// Read the GlobalStakeAmountNanos from the UtxoView.
-	if bav.GlobalStakeAmountNanos != nil {
-		return bav.GlobalStakeAmountNanos.Clone(), nil
+func (bav *UtxoView) GetGlobalActiveStakeAmountNanos() (*uint256.Int, error) {
+	// Read the GlobalActiveStakeAmountNanos from the UtxoView.
+	if bav.GlobalActiveStakeAmountNanos != nil {
+		return bav.GlobalActiveStakeAmountNanos.Clone(), nil
 	}
-	// If not set, read the GlobalStakeAmountNanos from the db.
-	globalStakeAmountNanos, err := DBGetGlobalStakeAmountNanos(bav.Handle, bav.Snapshot)
+	// If not set, read the GlobalActiveStakeAmountNanos from the db.
+	globalActiveStakeAmountNanos, err := DBGetGlobalActiveStakeAmountNanos(bav.Handle, bav.Snapshot)
 	if err != nil {
-		return nil, errors.Wrapf(err, "UtxoView.GetGlobalStakeAmountNanos: ")
+		return nil, errors.Wrapf(err, "UtxoView.GetGlobalActiveStakeAmountNanos: ")
 	}
-	if globalStakeAmountNanos == nil {
-		globalStakeAmountNanos = uint256.NewInt()
+	if globalActiveStakeAmountNanos == nil {
+		globalActiveStakeAmountNanos = uint256.NewInt()
 	}
-	// Cache the GlobalStakeAmountNanos from the db in the UtxoView.
-	bav._setGlobalStakeAmountNanos(globalStakeAmountNanos)
-	return globalStakeAmountNanos, nil
+	// Cache the GlobalActiveStakeAmountNanos from the db in the UtxoView.
+	bav._setGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos)
+	return globalActiveStakeAmountNanos, nil
+}
+
+func (bav *UtxoView) JailValidator(validatorEntry *ValidatorEntry) error {
+	// Retrieve the CurrentEpochNumber.
+	currentEpochNumber, err := bav.GetCurrentEpochNumber()
+	if err != nil {
+		return errors.Wrapf(err, "UtxoView.JailValidator: error retrieving CurrentEpochNumber: ")
+	}
+
+	// Set JailedAtEpochNumber = CurrentEpochNumber.
+	validatorEntry.JailedAtEpochNumber = currentEpochNumber
+
+	// Store the updated ValidatorEntry.
+	bav._setValidatorEntryMappings(validatorEntry)
+
+	// Remove the validator's stake from the GlobalActiveStakeAmountNanos.
+	prevGlobalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
+	if err != nil {
+		return errors.Wrapf(err, "UtxoView.JailValidator: error retrieving GlobalActiveStakeAmountNanos: ")
+	}
+	currentGlobalActiveStakeAmountNanos, err := SafeUint256().Sub(
+		prevGlobalActiveStakeAmountNanos, validatorEntry.TotalStakeAmountNanos,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "UtxoView.JailValidator: error calculating updated GlobalActiveStakeAmountNanos: ")
+	}
+	bav._setGlobalActiveStakeAmountNanos(currentGlobalActiveStakeAmountNanos)
+
+	return nil
 }
 
 func (bav *UtxoView) _setValidatorEntryMappings(validatorEntry *ValidatorEntry) {
@@ -1900,13 +1952,13 @@ func (bav *UtxoView) _deleteValidatorEntryMappings(validatorEntry *ValidatorEntr
 	bav._setValidatorEntryMappings(&tombstoneEntry)
 }
 
-func (bav *UtxoView) _setGlobalStakeAmountNanos(globalStakeAmountNanos *uint256.Int) {
+func (bav *UtxoView) _setGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos *uint256.Int) {
 	// This function shouldn't be called with nil.
-	if globalStakeAmountNanos == nil {
-		glog.Errorf("_setGlobalStakeAmountNanos: called with nil entry, this should never happen")
+	if globalActiveStakeAmountNanos == nil {
+		glog.Errorf("_setGlobalActiveStakeAmountNanos: called with nil entry, this should never happen")
 		return
 	}
-	bav.GlobalStakeAmountNanos = globalStakeAmountNanos.Clone()
+	bav.GlobalActiveStakeAmountNanos = globalActiveStakeAmountNanos.Clone()
 }
 
 func (bav *UtxoView) _flushValidatorEntriesToDbWithTxn(txn *badger.Txn, blockHeight uint64) error {
@@ -1951,14 +2003,14 @@ func (bav *UtxoView) _flushValidatorEntriesToDbWithTxn(txn *badger.Txn, blockHei
 	return nil
 }
 
-func (bav *UtxoView) _flushGlobalStakeAmountNanosToDbWithTxn(txn *badger.Txn, blockHeight uint64) error {
-	// If GlobalStakeAmountNanos is nil, then it was never
+func (bav *UtxoView) _flushGlobalActiveStakeAmountNanosToDbWithTxn(txn *badger.Txn, blockHeight uint64) error {
+	// If GlobalActiveStakeAmountNanos is nil, then it was never
 	// set and shouldn't overwrite the value in the db.
-	if bav.GlobalStakeAmountNanos == nil {
+	if bav.GlobalActiveStakeAmountNanos == nil {
 		return nil
 	}
 
-	return DBPutGlobalStakeAmountNanosWithTxn(txn, bav.Snapshot, bav.GlobalStakeAmountNanos, blockHeight)
+	return DBPutGlobalActiveStakeAmountNanosWithTxn(txn, bav.Snapshot, bav.GlobalActiveStakeAmountNanos, blockHeight)
 }
 
 //

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -486,9 +486,9 @@ type DBPrefixes struct {
 	// Note that we save space by storing a nil value and parsing the ValidatorPKID from the key.
 	PrefixValidatorByStake []byte `prefix_id:"[79]" is_state:"true"`
 
-	// PrefixGlobalStakeAmountNanos: Retrieve the cumulative stake across all validators.
+	// PrefixGlobalActiveStakeAmountNanos: Retrieve the cumulative stake across all validators.
 	// Prefix -> *uint256.Int
-	PrefixGlobalStakeAmountNanos []byte `prefix_id:"[80]" is_state:"true"`
+	PrefixGlobalActiveStakeAmountNanos []byte `prefix_id:"[80]" is_state:"true"`
 
 	// PrefixStakeByValidatorAndStaker: Retrieve a StakeEntry.
 	// Prefix, ValidatorPKID, StakerPKID -> StakeEntry
@@ -733,7 +733,7 @@ func StatePrefixToDeSoEncoder(prefix []byte) (_isEncoder bool, _encoder DeSoEnco
 	} else if bytes.Equal(prefix, Prefixes.PrefixValidatorByStake) {
 		// prefix_id:"[79]"
 		return false, nil
-	} else if bytes.Equal(prefix, Prefixes.PrefixGlobalStakeAmountNanos) {
+	} else if bytes.Equal(prefix, Prefixes.PrefixGlobalActiveStakeAmountNanos) {
 		// prefix_id:"[80]"
 		return false, nil
 	} else if bytes.Equal(prefix, Prefixes.PrefixStakeByValidatorAndStaker) {


### PR DESCRIPTION
This PR removes any jailed stake from our GlobalActiveStakeAmountNanos value. If a validator is jailed, we do not want to consider their stake in the total active stake across validators used in determining if we have a 2/3rd consensus on votes. This PR makes the following changes:

1. Renames `GlobalStakeAmountNanos` to `GlobalActiveStakeAmountNanos`. Note the addition of the keyword `Active`. This value describes the total active stake across validators, excluding any jailed validators' stake.
2. When a user stakes with a validator, we only add the additional stake to the `GlobalActiveStakeAmountNanos` if the validator isn't jailed.
3. When a user unstakes from a validator, we only subtract the decreased stake from the `GlobalActiveStakeAmountNanos` if the validator isn't jailed.
4. When a validator is jailed, we subtract their `TotalStakeAmountNanos` from the `GlobalActiveStakeAmountNanos`.
5. When a validator unjails himself, we add back their `TotalStakeAmountNanos` to the `GlobalActiveStakeAmountNanos`.
6. When a validator unregisters, we only subtract their now unstaked `TotalStakeAmountNanos` from the `GlobalActiveStakeAmountNanos` it they weren't jailed.