### PR TITLE
Update sign BLS test helper func signature.

### DIFF
--- a/lib/block_view_stake_test.go
+++ b/lib/block_view_stake_test.go
@@ -102,7 +102,7 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		GlobalDeSoParams.EncoderMigrationHeights = GetEncoderMigrationHeights(&params.ForkHeights)
 		GlobalDeSoParams.EncoderMigrationHeightsList = GetEncoderMigrationHeightsList(&params.ForkHeights)
 
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerAsValidatorMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -957,7 +957,7 @@ func TestStakingWithDerivedKey(t *testing.T) {
 	}
 	{
 		// m0 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerAsValidatorMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example1.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -968,7 +968,7 @@ func TestStakingWithDerivedKey(t *testing.T) {
 	}
 	{
 		// m1 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m1PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m1PkBytes)
 		registerAsValidatorMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example2.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -1844,7 +1844,7 @@ func TestStakeLockupEpochDuration(t *testing.T) {
 	}
 	{
 		// m0 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m1.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -2039,7 +2039,7 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m0.example.com")},
 			VotingPublicKey:          votingPublicKey,

--- a/lib/block_view_validator_test.go
+++ b/lib/block_view_validator_test.go
@@ -92,7 +92,7 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 		GlobalDeSoParams.EncoderMigrationHeights = GetEncoderMigrationHeights(&params.ForkHeights)
 		GlobalDeSoParams.EncoderMigrationHeightsList = GetEncoderMigrationHeightsList(&params.ForkHeights)
 
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata = &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example.com")},
 			DisableDelegatedStake:    false,
@@ -164,7 +164,7 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 	}
 	{
 		// RuleErrorValidatorMissingVotingPublicKeySignature
-		votingPublicKey, _ := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, _ := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata = &RegisterAsValidatorMetadata{
 			Domains:         [][]byte{[]byte("https://example.com")},
 			VotingPublicKey: votingPublicKey,
@@ -177,7 +177,7 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 	}
 	{
 		// RuleErrorValidatorInvalidVotingPublicKeySignature: invalid TransactorPkBytes
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m1PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m1PkBytes)
 		registerMetadata = &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -191,8 +191,8 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 	}
 	{
 		// RuleErrorValidatorInvalidVotingPublicKeySignature: invalid VotingPublicKey
-		votingPublicKey, _ := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
-		_, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, _ := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
+		_, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata = &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -206,7 +206,7 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 	}
 	{
 		// Happy path: register a validator
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata = &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example.com")},
 			DisableDelegatedStake:    false,
@@ -242,7 +242,7 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 	}
 	{
 		// Happy path: update a validator
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata = &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example1.com"), []byte("https://example2.com")},
 			DisableDelegatedStake:    false,
@@ -605,7 +605,7 @@ func TestValidatorRegistrationWithDerivedKey(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a VotingPublicKey and VotingSignature.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, senderPkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, senderPkBytes)
 
 		// Perform a RegisterAsValidator txn. No error expected.
 		registerAsValidatorMetadata := &RegisterAsValidatorMetadata{
@@ -671,7 +671,7 @@ func TestValidatorRegistrationWithDerivedKey(t *testing.T) {
 		require.Contains(t, err.Error(), RuleErrorValidatorNotFound)
 
 		// Create a VotingPublicKey and VotingSignature.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, senderPkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, senderPkBytes)
 
 		// Perform a RegisterAsValidator txn. Error expected.
 		registerAsValidatorMetadata := &RegisterAsValidatorMetadata{
@@ -773,7 +773,7 @@ func _testGetTopActiveValidatorsByStake(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m0.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -789,7 +789,7 @@ func _testGetTopActiveValidatorsByStake(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m1 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m1PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m1PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m1.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -805,7 +805,7 @@ func _testGetTopActiveValidatorsByStake(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m2 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m2PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m2PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m2.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -977,7 +977,7 @@ func TestGetTopActiveValidatorsByStakeMergingDbAndUtxoView(t *testing.T) {
 	m5PKID := DBGetPKIDEntryForPublicKey(db, chain.snapshot, m5PkBytes).PKID
 
 	// Store m0's ValidatorEntry in the db with TotalStake = 100 nanos.
-	votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+	votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 	validatorEntry := &ValidatorEntry{
 		ValidatorPKID:            m0PKID,
 		TotalStakeAmountNanos:    uint256.NewInt().SetUint64(100),
@@ -997,7 +997,7 @@ func TestGetTopActiveValidatorsByStakeMergingDbAndUtxoView(t *testing.T) {
 	require.Empty(t, utxoView.ValidatorPKIDToValidatorEntry)
 
 	// Store m1's jailed ValidatorEntry in the db with TotalStake = 400 nanos.
-	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m1PkBytes, blockHeight)
+	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m1PkBytes)
 	validatorEntry = &ValidatorEntry{
 		ValidatorPKID:            m1PKID,
 		TotalStakeAmountNanos:    uint256.NewInt().SetUint64(400),
@@ -1016,7 +1016,7 @@ func TestGetTopActiveValidatorsByStakeMergingDbAndUtxoView(t *testing.T) {
 	require.Equal(t, validatorEntry.Status(), ValidatorStatusJailed)
 
 	// Store m2's ValidatorEntry in the db with TotalStake = 300 nanos.
-	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m2PkBytes, blockHeight)
+	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m2PkBytes)
 	m2ValidatorEntry := &ValidatorEntry{
 		ValidatorPKID:            m2PKID,
 		TotalStakeAmountNanos:    uint256.NewInt().SetUint64(300),
@@ -1033,7 +1033,7 @@ func TestGetTopActiveValidatorsByStakeMergingDbAndUtxoView(t *testing.T) {
 	require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(300))
 
 	// Store m3's ValidatorEntry in the db with TotalStake = 600 nanos.
-	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m3PkBytes, blockHeight)
+	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m3PkBytes)
 	m3ValidatorEntry := &ValidatorEntry{
 		ValidatorPKID:            m3PKID,
 		TotalStakeAmountNanos:    uint256.NewInt().SetUint64(600),
@@ -1071,7 +1071,7 @@ func TestGetTopActiveValidatorsByStakeMergingDbAndUtxoView(t *testing.T) {
 	require.True(t, utxoView.ValidatorPKIDToValidatorEntry[*m3ValidatorEntry.ValidatorPKID].isDeleted)
 
 	// Store m4's ValidatorEntry in the UtxoView with TotalStake = 50 nanos.
-	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m4PkBytes, blockHeight)
+	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m4PkBytes)
 	m4ValidatorEntry := &ValidatorEntry{
 		ValidatorPKID:            m4PKID,
 		TotalStakeAmountNanos:    uint256.NewInt().SetUint64(50),
@@ -1095,7 +1095,7 @@ func TestGetTopActiveValidatorsByStakeMergingDbAndUtxoView(t *testing.T) {
 	)
 
 	// Store m5's jailed ValidatorEntry in the UtxoView with TotalStake = 500 nanos.
-	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m5PkBytes, blockHeight)
+	votingPublicKey, votingSignature = _generateVotingPublicKeyAndSignature(t, m5PkBytes)
 	m5ValidatorEntry := &ValidatorEntry{
 		ValidatorPKID:            m5PKID,
 		TotalStakeAmountNanos:    uint256.NewInt().SetUint64(500),
@@ -1211,7 +1211,7 @@ func _testUpdatingValidatorDisableDelegatedStake(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 registers as a validator with DisableDelegatedStake = FALSE.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m0.com")},
 			DisableDelegatedStake:    false,
@@ -1232,7 +1232,7 @@ func _testUpdatingValidatorDisableDelegatedStake(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 updates DisableDelegatedStake = TRUE.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m0.com")},
 			DisableDelegatedStake:    true,
@@ -1277,7 +1277,7 @@ func _testUpdatingValidatorDisableDelegatedStake(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 updates DisableDelegatedStake = FALSE.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m0.com")},
 			DisableDelegatedStake:    false,
@@ -1309,7 +1309,7 @@ func _testUpdatingValidatorDisableDelegatedStake(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 tries to update DisableDelegateStake = TRUE. Errors.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m0.com")},
 			DisableDelegatedStake:    true,
@@ -1409,7 +1409,7 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://m0.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -1615,7 +1615,7 @@ func _testUnjailValidator(t *testing.T, flushToDB bool) {
 	}
 	{
 		// m0 registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, m0PkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -1917,7 +1917,7 @@ func TestUnjailValidatorWithDerivedKey(t *testing.T) {
 	}
 	{
 		// sender registers as a validator.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, senderPkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, senderPkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte("https://example.com")},
 			VotingPublicKey:          votingPublicKey,
@@ -2060,7 +2060,7 @@ func _submitUnjailValidatorTxn(
 	return fees, nil
 }
 
-func _generateVotingPublicKeyAndSignature(t *testing.T, transactorPkBytes []byte, blockHeight uint64) (*bls.PublicKey, *bls.Signature) {
+func _generateVotingPublicKeyAndSignature(t *testing.T, transactorPkBytes []byte) (*bls.PublicKey, *bls.Signature) {
 	blsPrivateKey, err := bls.NewPrivateKey()
 	require.NoError(t, err)
 	votingPublicKey := blsPrivateKey.PublicKey()

--- a/lib/pos_leader_schedule_test.go
+++ b/lib/pos_leader_schedule_test.go
@@ -73,7 +73,7 @@ func TestGenerateLeaderSchedule(t *testing.T) {
 		require.NoError(t, err)
 
 		// Validator registers.
-		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, pkBytes, blockHeight)
+		votingPublicKey, votingSignature := _generateVotingPublicKeyAndSignature(t, pkBytes)
 		registerMetadata := &RegisterAsValidatorMetadata{
 			Domains:                  [][]byte{[]byte(fmt.Sprintf("https://%s.com", publicKey))},
 			VotingPublicKey:          votingPublicKey,


### PR DESCRIPTION
Before, we were using a VotingSignatureBlockHeight in our VotingSignatures. Now we only sign the TransactorPublicKey. So this PR just updates the test helper to remove the unused function parameter in the test helper.