### PR TITLE
Mf/jail inactive validators

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -3041,6 +3041,16 @@ func (bav *UtxoView) _connectUpdateGlobalParams(
 				return 0, 0, nil, fmt.Errorf("_connectUpdateGlobalParams: unable to decode EpochDurationNumBlocks as uint64")
 			}
 		}
+		if len(extraData[JailInactiveValidatorGracePeriodEpochs.ToString()]) > 0 {
+			newGlobalParamsEntry.JailInactiveValidatorGracePeriodEpochs, bytesRead = Uvarint(
+				extraData[JailInactiveValidatorGracePeriodEpochs.ToString()],
+			)
+			if bytesRead <= 0 {
+				return 0, 0, nil, fmt.Errorf(
+					"_connectUpdateGlobalParams: unable to decode JailInactiveValidatorGracePeriodEpochs as uint64",
+				)
+			}
+		}
 	}
 
 	var newForbiddenPubKeyEntry *ForbiddenPubKeyEntry

--- a/lib/block_view_stake.go
+++ b/lib/block_view_stake.go
@@ -1954,7 +1954,7 @@ func (bav *UtxoView) IsValidUnlockStakeMetadata(transactorPkBytes []byte, metada
 		return errors.Wrapf(err, "UtxoView.IsValidUnlockStakeMetadata: error retrieving CurrentEpochNumber: ")
 	}
 
-	// Retrieve SnapshotGlobalParam: StakeLockupEpochDuration.
+	// Retrieve the SnapshotGlobalParam: StakeLockupEpochDuration.
 	stakeLockupEpochDuration, err := bav.GetSnapshotGlobalParam(StakeLockupEpochDuration)
 	if err != nil {
 		return errors.Wrapf(err, "UtxoView.IsValidUnlockStakeMetadata: error retrieving snapshot StakeLockupEpochDuration: ")

--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -3787,6 +3787,11 @@ type GlobalParamsEntry struct {
 
 	// EpochDurationNumBlocks is the number of blocks included in one epoch.
 	EpochDurationNumBlocks uint64
+
+	// JailInactiveValidatorEpochThreshold is the number of epochs we allow
+	// a validator to be inactive for (neither voting nor proposing blocks)
+	// before they are jailed.
+	JailInactiveValidatorEpochThreshold uint64
 }
 
 func (gp *GlobalParamsEntry) Copy() *GlobalParamsEntry {
@@ -3801,6 +3806,7 @@ func (gp *GlobalParamsEntry) Copy() *GlobalParamsEntry {
 		ValidatorJailEpochDuration:          gp.ValidatorJailEpochDuration,
 		LeaderScheduleMaxNumValidators:      gp.LeaderScheduleMaxNumValidators,
 		EpochDurationNumBlocks:              gp.EpochDurationNumBlocks,
+		JailInactiveValidatorEpochThreshold: gp.JailInactiveValidatorEpochThreshold,
 	}
 }
 
@@ -3820,6 +3826,7 @@ func (gp *GlobalParamsEntry) RawEncodeWithoutMetadata(blockHeight uint64, skipMe
 		data = append(data, UintToBuf(gp.ValidatorJailEpochDuration)...)
 		data = append(data, UintToBuf(gp.LeaderScheduleMaxNumValidators)...)
 		data = append(data, UintToBuf(gp.EpochDurationNumBlocks)...)
+		data = append(data, UintToBuf(gp.JailInactiveValidatorEpochThreshold)...)
 	}
 	return data
 }
@@ -3869,6 +3876,10 @@ func (gp *GlobalParamsEntry) RawDecodeWithoutMetadata(blockHeight uint64, rr *by
 		gp.EpochDurationNumBlocks, err = ReadUvarint(rr)
 		if err != nil {
 			return errors.Wrapf(err, "GlobalParamsEntry.Decode: Problem reading EpochDurationNumBlocks: ")
+		}
+		gp.JailInactiveValidatorEpochThreshold, err = ReadUvarint(rr)
+		if err != nil {
+			return errors.Wrapf(err, "GlobalParamsEntry.Decode: Problem reading JailInactiveValidatorEpochThreshold: ")
 		}
 	}
 	return nil

--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -3788,25 +3788,25 @@ type GlobalParamsEntry struct {
 	// EpochDurationNumBlocks is the number of blocks included in one epoch.
 	EpochDurationNumBlocks uint64
 
-	// JailInactiveValidatorEpochThreshold is the number of epochs we allow
-	// a validator to be inactive for (neither voting nor proposing blocks)
-	// before they are jailed.
-	JailInactiveValidatorEpochThreshold uint64
+	// JailInactiveValidatorGracePeriodEpochs is the number of epochs we
+	// allow a validator to be inactive for (neither voting nor proposing
+	// blocks) before they are jailed.
+	JailInactiveValidatorGracePeriodEpochs uint64
 }
 
 func (gp *GlobalParamsEntry) Copy() *GlobalParamsEntry {
 	return &GlobalParamsEntry{
-		USDCentsPerBitcoin:                  gp.USDCentsPerBitcoin,
-		CreateProfileFeeNanos:               gp.CreateProfileFeeNanos,
-		CreateNFTFeeNanos:                   gp.CreateNFTFeeNanos,
-		MaxCopiesPerNFT:                     gp.MaxCopiesPerNFT,
-		MinimumNetworkFeeNanosPerKB:         gp.MinimumNetworkFeeNanosPerKB,
-		MaxNonceExpirationBlockHeightOffset: gp.MaxNonceExpirationBlockHeightOffset,
-		StakeLockupEpochDuration:            gp.StakeLockupEpochDuration,
-		ValidatorJailEpochDuration:          gp.ValidatorJailEpochDuration,
-		LeaderScheduleMaxNumValidators:      gp.LeaderScheduleMaxNumValidators,
-		EpochDurationNumBlocks:              gp.EpochDurationNumBlocks,
-		JailInactiveValidatorEpochThreshold: gp.JailInactiveValidatorEpochThreshold,
+		USDCentsPerBitcoin:                     gp.USDCentsPerBitcoin,
+		CreateProfileFeeNanos:                  gp.CreateProfileFeeNanos,
+		CreateNFTFeeNanos:                      gp.CreateNFTFeeNanos,
+		MaxCopiesPerNFT:                        gp.MaxCopiesPerNFT,
+		MinimumNetworkFeeNanosPerKB:            gp.MinimumNetworkFeeNanosPerKB,
+		MaxNonceExpirationBlockHeightOffset:    gp.MaxNonceExpirationBlockHeightOffset,
+		StakeLockupEpochDuration:               gp.StakeLockupEpochDuration,
+		ValidatorJailEpochDuration:             gp.ValidatorJailEpochDuration,
+		LeaderScheduleMaxNumValidators:         gp.LeaderScheduleMaxNumValidators,
+		EpochDurationNumBlocks:                 gp.EpochDurationNumBlocks,
+		JailInactiveValidatorGracePeriodEpochs: gp.JailInactiveValidatorGracePeriodEpochs,
 	}
 }
 
@@ -3826,7 +3826,7 @@ func (gp *GlobalParamsEntry) RawEncodeWithoutMetadata(blockHeight uint64, skipMe
 		data = append(data, UintToBuf(gp.ValidatorJailEpochDuration)...)
 		data = append(data, UintToBuf(gp.LeaderScheduleMaxNumValidators)...)
 		data = append(data, UintToBuf(gp.EpochDurationNumBlocks)...)
-		data = append(data, UintToBuf(gp.JailInactiveValidatorEpochThreshold)...)
+		data = append(data, UintToBuf(gp.JailInactiveValidatorGracePeriodEpochs)...)
 	}
 	return data
 }
@@ -3877,9 +3877,9 @@ func (gp *GlobalParamsEntry) RawDecodeWithoutMetadata(blockHeight uint64, rr *by
 		if err != nil {
 			return errors.Wrapf(err, "GlobalParamsEntry.Decode: Problem reading EpochDurationNumBlocks: ")
 		}
-		gp.JailInactiveValidatorEpochThreshold, err = ReadUvarint(rr)
+		gp.JailInactiveValidatorGracePeriodEpochs, err = ReadUvarint(rr)
 		if err != nil {
-			return errors.Wrapf(err, "GlobalParamsEntry.Decode: Problem reading JailInactiveValidatorEpochThreshold: ")
+			return errors.Wrapf(err, "GlobalParamsEntry.Decode: Problem reading JailInactiveValidatorGracePeriodEpochs: ")
 		}
 	}
 	return nil

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1929,6 +1929,12 @@ func (bav *UtxoView) ShouldJailValidator(validatorEntry *ValidatorEntry, blockHe
 	// there would be an edge case where all validators will get jailed
 	// after we deploy the StateSetup block height, but before we deploy
 	// the ConsensusCutover block height.
+	//
+	// We do another check below to make sure enough blocks have passed even
+	// after we cut-over to PoS, but since this check is so quick to perform,
+	// we keep this one here as well, since this will catch all OnEpochCompleteHooks
+	// after the StateSetup block height and before the CutoverConsensus block height
+	// and saves us a few look-ups and computations.
 	if blockHeight < uint64(bav.Params.ForkHeights.ProofOfStake2ConsensusCutoverBlockHeight) {
 		return false, nil
 	}
@@ -1940,16 +1946,42 @@ func (bav *UtxoView) ShouldJailValidator(validatorEntry *ValidatorEntry, blockHe
 		return false, nil
 	}
 
-	// Retrieve the CurrentEpochNumber.
-	currentEpochNumber, err := bav.GetCurrentEpochNumber()
-	if err != nil {
-		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving CurrentEpochNumber: ")
-	}
-
 	// Retrieve the SnapshotGlobalParam: JailInactiveValidatorGracePeriodEpochs.
 	jailInactiveValidatorGracePeriodEpochs, err := bav.GetSnapshotGlobalParam(JailInactiveValidatorGracePeriodEpochs)
 	if err != nil {
 		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving JailInactiveValidatorGracePeriodEpochs: ")
+	}
+
+	// Retrieve the SnapshotGlobalParam: EpochDurationNumBlocks.
+	epochDurationNumBlocks, err := bav.GetSnapshotGlobalParam(EpochDurationNumBlocks)
+	if err != nil {
+		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving EpochDurationNumBlocks: ")
+	}
+
+	// Calculate if enough blocks have passed since cutting over to PoS to start jailing validators.
+	// We want to allow a buffer after we cut-over to PoS to allow validators enough time to vote.
+	// Otherwise, validators may be jailed prior to the "jail inactive validators grace period"
+	// elapsing since all validators' LastActiveAtEpochNumber = 0 prior to the PoS cut-over.
+	//
+	// StartJailingBlockHeight = ConsensusCutoverBlockHeight + (JailInactiveValidatorGracePeriodEpochs * EpochDurationNumBlocks)
+	startJailingGracePeriodBlocks, err := SafeUint64().Mul(jailInactiveValidatorGracePeriodEpochs, epochDurationNumBlocks)
+	if err != nil {
+		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error calculating StartJailingGracePeriod: ")
+	}
+	startJailingBlockHeight, err := SafeUint64().Add(
+		uint64(bav.Params.ForkHeights.ProofOfStake2ConsensusCutoverBlockHeight), startJailingGracePeriodBlocks,
+	)
+	if err != nil {
+		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error calculating StartJailingBlockHeight: ")
+	}
+	if blockHeight < startJailingBlockHeight {
+		return false, nil
+	}
+
+	// Retrieve the CurrentEpochNumber.
+	currentEpochNumber, err := bav.GetCurrentEpochNumber()
+	if err != nil {
+		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving CurrentEpochNumber: ")
 	}
 
 	// Calculate the JailAtEpochNumber.

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1926,7 +1926,7 @@ func (bav *UtxoView) GetGlobalActiveStakeAmountNanos() (*uint256.Int, error) {
 
 func (bav *UtxoView) ShouldJailValidator(validatorEntry *ValidatorEntry) (bool, error) {
 	// Return false if the validator is already jailed. We do not want to jail
-	// them again. And we want to retain their original JailedAtEpochNumber so
+	// them again as we want to retain their original JailedAtEpochNumber so
 	// that they can eventually unjail themselves.
 	if validatorEntry.Status() == ValidatorStatusJailed {
 		return false, nil
@@ -1944,7 +1944,7 @@ func (bav *UtxoView) ShouldJailValidator(validatorEntry *ValidatorEntry) (bool, 
 		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving JailInactiveValidatorGracePeriodEpochs: ")
 	}
 
-	// Calculate JailAtEpochNumber.
+	// Calculate the JailAtEpochNumber.
 	jailAtEpochNumber, err := SafeUint64().Add(validatorEntry.LastActiveAtEpochNumber, jailInactiveValidatorGracePeriodEpochs)
 	if err != nil {
 		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error calculating JailAtEpochNumber: ")

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1938,19 +1938,19 @@ func (bav *UtxoView) ShouldJailValidator(validatorEntry *ValidatorEntry) (bool, 
 		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving CurrentEpochNumber: ")
 	}
 
-	// Retrieve the SnapshotGlobalParam: JailInactiveValidatorEpochThreshold.
-	jailInactiveValidatorEpochThreshold, err := bav.GetSnapshotGlobalParam(JailInactiveValidatorEpochThreshold)
+	// Retrieve the SnapshotGlobalParam: JailInactiveValidatorGracePeriodEpochs.
+	jailInactiveValidatorGracePeriodEpochs, err := bav.GetSnapshotGlobalParam(JailInactiveValidatorGracePeriodEpochs)
 	if err != nil {
-		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving JailInactiveValidatorEpochThreshold: ")
+		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error retrieving JailInactiveValidatorGracePeriodEpochs: ")
 	}
 
 	// Calculate JailAtEpochNumber.
-	jailAtEpochNumber, err := SafeUint64().Add(validatorEntry.LastActiveAtEpochNumber, jailInactiveValidatorEpochThreshold)
+	jailAtEpochNumber, err := SafeUint64().Add(validatorEntry.LastActiveAtEpochNumber, jailInactiveValidatorGracePeriodEpochs)
 	if err != nil {
 		return false, errors.Wrapf(err, "UtxoView.ShouldJailValidator: error calculating JailAtEpochNumber: ")
 	}
 
-	// Return true if LastActiveAtEpochNumber + JailInactiveValidatorEpochThreshold <= CurrentEpochNumber.
+	// Return true if LastActiveAtEpochNumber + JailInactiveValidatorGracePeriodEpochs <= CurrentEpochNumber.
 	return jailAtEpochNumber <= currentEpochNumber, nil
 }
 

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -630,6 +630,11 @@ type DeSoParams struct {
 	// DefaultEpochDurationNumBlocks is the default number of blocks included in one epoch.
 	DefaultEpochDurationNumBlocks uint64
 
+	// DefaultJailInactiveValidatorEpochThreshold is the default number of epochs
+	// we allow a validator to be inactive for (neither voting nor proposing blocks)
+	// before they are jailed.
+	DefaultJailInactiveValidatorEpochThreshold uint64
+
 	ForkHeights ForkHeights
 
 	EncoderMigrationHeights     *EncoderMigrationHeights
@@ -1022,6 +1027,9 @@ var DeSoMainnetParams = DeSoParams{
 	// The number of blocks in one epoch
 	DefaultEpochDurationNumBlocks: uint64(3600),
 
+	// The number of epochs before an inactive validator is jailed
+	DefaultJailInactiveValidatorEpochThreshold: uint64(48),
+
 	ForkHeights:                 MainnetForkHeights,
 	EncoderMigrationHeights:     GetEncoderMigrationHeights(&MainnetForkHeights),
 	EncoderMigrationHeightsList: GetEncoderMigrationHeightsList(&MainnetForkHeights),
@@ -1267,6 +1275,9 @@ var DeSoTestnetParams = DeSoParams{
 
 	// The number of blocks in one epoch
 	DefaultEpochDurationNumBlocks: uint64(3600),
+
+	// The number of epochs before an inactive validator is jailed
+	DefaultJailInactiveValidatorEpochThreshold: uint64(48),
 
 	ForkHeights:                 TestnetForkHeights,
 	EncoderMigrationHeights:     GetEncoderMigrationHeights(&TestnetForkHeights),

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -630,10 +630,10 @@ type DeSoParams struct {
 	// DefaultEpochDurationNumBlocks is the default number of blocks included in one epoch.
 	DefaultEpochDurationNumBlocks uint64
 
-	// DefaultJailInactiveValidatorEpochThreshold is the default number of epochs
+	// DefaultJailInactiveValidatorGracePeriodEpochs is the default number of epochs
 	// we allow a validator to be inactive for (neither voting nor proposing blocks)
 	// before they are jailed.
-	DefaultJailInactiveValidatorEpochThreshold uint64
+	DefaultJailInactiveValidatorGracePeriodEpochs uint64
 
 	ForkHeights ForkHeights
 
@@ -1028,7 +1028,7 @@ var DeSoMainnetParams = DeSoParams{
 	DefaultEpochDurationNumBlocks: uint64(3600),
 
 	// The number of epochs before an inactive validator is jailed
-	DefaultJailInactiveValidatorEpochThreshold: uint64(48),
+	DefaultJailInactiveValidatorGracePeriodEpochs: uint64(48),
 
 	ForkHeights:                 MainnetForkHeights,
 	EncoderMigrationHeights:     GetEncoderMigrationHeights(&MainnetForkHeights),
@@ -1277,7 +1277,7 @@ var DeSoTestnetParams = DeSoParams{
 	DefaultEpochDurationNumBlocks: uint64(3600),
 
 	// The number of epochs before an inactive validator is jailed
-	DefaultJailInactiveValidatorEpochThreshold: uint64(48),
+	DefaultJailInactiveValidatorGracePeriodEpochs: uint64(48),
 
 	ForkHeights:                 TestnetForkHeights,
 	EncoderMigrationHeights:     GetEncoderMigrationHeights(&TestnetForkHeights),

--- a/lib/pos_epoch_complete_hook.go
+++ b/lib/pos_epoch_complete_hook.go
@@ -50,8 +50,8 @@ func (bav *UtxoView) RunEpochCompleteHook(blockHeight uint64) error {
 	// Snapshot the current GlobalParamsEntry.
 	bav._setSnapshotGlobalParamsEntry(bav.GlobalParamsEntry, currentEpochEntry.EpochNumber)
 
-	// Snapshot the current ValidatorEntries. This loops through all validators to snapshot them, O(N).
-	// To save on runtime, we also check if we should jail each validator and jail them if so.
+	// Snapshot the current ValidatorEntries. This loops through all validators to snapshot them in O(N).
+	// To save on runtime, in this loop we also check if we should jail each validator and jail them if so.
 	// We optionally jail a validator after we snapshot them. A jailed validator should be considered jailed
 	// in the new epoch starting after this OnEpochCompleteHook, and not the previous epoch which is snapshot.
 	if err = bav.SnapshotCurrentValidators(currentEpochEntry.EpochNumber); err != nil {

--- a/lib/pos_epoch_complete_hook.go
+++ b/lib/pos_epoch_complete_hook.go
@@ -54,7 +54,7 @@ func (bav *UtxoView) RunEpochCompleteHook(blockHeight uint64) error {
 	// To save on runtime, in this loop we also check if we should jail each validator and jail them if so.
 	// We optionally jail a validator after we snapshot them. A jailed validator should be considered jailed
 	// in the new epoch starting after this OnEpochCompleteHook, and not the previous epoch which is snapshot.
-	if err = bav.SnapshotCurrentValidators(currentEpochEntry.EpochNumber); err != nil {
+	if err = bav.SnapshotCurrentValidators(currentEpochEntry.EpochNumber, blockHeight); err != nil {
 		return errors.Wrapf(err, "RunEpochCompleteHook: problem snapshotting validators: ")
 	}
 

--- a/lib/pos_snapshot_entries.go
+++ b/lib/pos_snapshot_entries.go
@@ -32,10 +32,11 @@ func (bav *UtxoView) GetSnapshotEpochNumber() (uint64, error) {
 type SnapshotGlobalParam string
 
 const (
-	StakeLockupEpochDuration       SnapshotGlobalParam = "StakeLockupEpochDuration"
-	ValidatorJailEpochDuration     SnapshotGlobalParam = "ValidatorJailEpochDuration"
-	LeaderScheduleMaxNumValidators SnapshotGlobalParam = "LeaderScheduleMaxNumValidators"
-	EpochDurationNumBlocks         SnapshotGlobalParam = "EpochDurationNumBlocks"
+	StakeLockupEpochDuration            SnapshotGlobalParam = "StakeLockupEpochDuration"
+	ValidatorJailEpochDuration          SnapshotGlobalParam = "ValidatorJailEpochDuration"
+	LeaderScheduleMaxNumValidators      SnapshotGlobalParam = "LeaderScheduleMaxNumValidators"
+	EpochDurationNumBlocks              SnapshotGlobalParam = "EpochDurationNumBlocks"
+	JailInactiveValidatorEpochThreshold SnapshotGlobalParam = "JailInactiveValidatorEpochThreshold"
 )
 
 func (snapshotGlobalParam SnapshotGlobalParam) ToString() string {
@@ -49,7 +50,7 @@ func (bav *UtxoView) GetSnapshotGlobalParam(field SnapshotGlobalParam) (uint64, 
 		return 0, errors.Wrapf(err, "GetSnapshotGlobalParam: problem retrieving SnapshotGlobalParamsEntry: ")
 	}
 	if globalParamsEntry == nil {
-		// We will use hte default values below.
+		// We will use the default values below.
 		globalParamsEntry = &GlobalParamsEntry{}
 	}
 
@@ -79,6 +80,12 @@ func (bav *UtxoView) GetSnapshotGlobalParam(field SnapshotGlobalParam) (uint64, 
 			return globalParamsEntry.EpochDurationNumBlocks, nil
 		}
 		return bav.Params.DefaultEpochDurationNumBlocks, nil
+
+	case JailInactiveValidatorEpochThreshold:
+		if globalParamsEntry.JailInactiveValidatorEpochThreshold != 0 {
+			return globalParamsEntry.JailInactiveValidatorEpochThreshold, nil
+		}
+		return bav.Params.DefaultJailInactiveValidatorEpochThreshold, nil
 	}
 
 	return 0, fmt.Errorf("GetSnapshotGlobalParam: invalid field provided: %s", field)
@@ -207,6 +214,23 @@ func (bav *UtxoView) SnapshotCurrentValidators(snapshotAtEpochNumber uint64) err
 		if !validatorEntry.isDeleted {
 			// We only want to snapshot !isDeleted ValidatorEntries.
 			bav._setSnapshotValidatorEntry(validatorEntry, snapshotAtEpochNumber)
+
+			// Check if we should jail the validator.
+			shouldJailValidator, err := bav.ShouldJailValidator(validatorEntry)
+			if err != nil {
+				return errors.Wrapf(
+					err, "SnapshotValidators: problem determining if should jail validator %v: ", validatorEntry.ValidatorPKID,
+				)
+			}
+			// Jail them if so.
+			if shouldJailValidator {
+				err = bav.JailValidator(validatorEntry)
+				if err != nil {
+					return errors.Wrapf(
+						err, "SnapshotValidators: problem jailing validator %v: ", validatorEntry.ValidatorPKID,
+					)
+				}
+			}
 		}
 		// We don't want to retrieve any ValidatorEntries from the db that are present in the UtxoView.
 		utxoViewValidatorPKIDs = append(utxoViewValidatorPKIDs, validatorEntry.ValidatorPKID)
@@ -218,6 +242,23 @@ func (bav *UtxoView) SnapshotCurrentValidators(snapshotAtEpochNumber uint64) err
 	}
 	for _, validatorEntry := range dbValidatorEntries {
 		bav._setSnapshotValidatorEntry(validatorEntry, snapshotAtEpochNumber)
+
+		// Check if we should jail the validator.
+		shouldJailValidator, err := bav.ShouldJailValidator(validatorEntry)
+		if err != nil {
+			return errors.Wrapf(
+				err, "SnapshotValidators: problem determining if should jail validator %v: ", validatorEntry.ValidatorPKID,
+			)
+		}
+		// Jail them if so.
+		if shouldJailValidator {
+			err = bav.JailValidator(validatorEntry)
+			if err != nil {
+				return errors.Wrapf(
+					err, "SnapshotValidators: problem jailing validator %v: ", validatorEntry.ValidatorPKID,
+				)
+			}
+		}
 	}
 	return nil
 }

--- a/lib/pos_snapshot_entries.go
+++ b/lib/pos_snapshot_entries.go
@@ -207,7 +207,7 @@ type SnapshotValidatorMapKey struct {
 	ValidatorPKID         PKID
 }
 
-func (bav *UtxoView) SnapshotCurrentValidators(snapshotAtEpochNumber uint64) error {
+func (bav *UtxoView) SnapshotCurrentValidators(snapshotAtEpochNumber uint64, blockHeight uint64) error {
 	// First, snapshot any !isDeleted ValidatorEntries in the UtxoView.
 	var utxoViewValidatorPKIDs []*PKID
 	for _, validatorEntry := range bav.ValidatorPKIDToValidatorEntry {
@@ -216,7 +216,7 @@ func (bav *UtxoView) SnapshotCurrentValidators(snapshotAtEpochNumber uint64) err
 			bav._setSnapshotValidatorEntry(validatorEntry, snapshotAtEpochNumber)
 
 			// Check if we should jail the validator.
-			shouldJailValidator, err := bav.ShouldJailValidator(validatorEntry)
+			shouldJailValidator, err := bav.ShouldJailValidator(validatorEntry, blockHeight)
 			if err != nil {
 				return errors.Wrapf(
 					err,
@@ -245,7 +245,7 @@ func (bav *UtxoView) SnapshotCurrentValidators(snapshotAtEpochNumber uint64) err
 		bav._setSnapshotValidatorEntry(validatorEntry, snapshotAtEpochNumber)
 
 		// Check if we should jail the validator.
-		shouldJailValidator, err := bav.ShouldJailValidator(validatorEntry)
+		shouldJailValidator, err := bav.ShouldJailValidator(validatorEntry, blockHeight)
 		if err != nil {
 			return errors.Wrapf(
 				err, "SnapshotValidators: problem determining if should jail validator %v: ", validatorEntry.ValidatorPKID,


### PR DESCRIPTION
This PR jails inactive validators. A validator stays active by either voting on blocks or proposing new blocks. When they participate in consensus by performing either of those actions, we update their LastActiveAtEpochNumber. If they fall inactive beyond our grace period (a param stored on the GlobalParamsEntry) we jail them. We run this logic in the OnEpochCompleteHook.