### PR TITLE
PoS Simplify PublicKey field names in P2P messages

### DIFF
--- a/lib/pos_network.go
+++ b/lib/pos_network.go
@@ -21,13 +21,13 @@ type MsgDeSoValidatorVote struct {
 	// Given the validator's ECDSA public key, we can look up their Validator PKID
 	// and their stake in consensus. This allows us to verify that the vote message
 	// was sent by a registered validator.
-	ValidatorPublicKey *PublicKey
+	PublicKey *PublicKey
 	// The BLS voting public key for the validator who constructed this vote message.
 	// The BLS public key is included in the vote message because it allows us to
 	// easily verify if the BLS VotePartialSignature is correctly formed, without having
 	// to first look up the validator's BLS public key in consensus. It helps optimize
 	// vote validation.
-	ValidatorVotingPublicKey *bls.PublicKey
+	VotingPublicKey *bls.PublicKey
 
 	// The block hash corresponding to the block that this vote is for.
 	BlockHash *BlockHash
@@ -55,17 +55,17 @@ func (msg *MsgDeSoValidatorVote) ToBytes(bool) ([]byte, error) {
 	// MsgVersion
 	retBytes = append(retBytes, msg.MsgVersion)
 
-	// ValidatorPublicKey
-	if msg.ValidatorPublicKey == nil {
-		return nil, errors.New("MsgDeSoValidatorVote.ToBytes: ValidatorPublicKey must not be nil")
+	// PublicKey
+	if msg.PublicKey == nil {
+		return nil, errors.New("MsgDeSoValidatorVote.ToBytes: PublicKey must not be nil")
 	}
-	retBytes = append(retBytes, msg.ValidatorPublicKey.ToBytes()...)
+	retBytes = append(retBytes, msg.PublicKey.ToBytes()...)
 
-	// ValidatorVotingPublicKey
-	if msg.ValidatorVotingPublicKey == nil {
-		return nil, errors.New("MsgDeSoValidatorVote.ToBytes: ValidatorVotingPublicKey must not be nil")
+	// VotingPublicKey
+	if msg.VotingPublicKey == nil {
+		return nil, errors.New("MsgDeSoValidatorVote.ToBytes: VotingPublicKey must not be nil")
 	}
-	retBytes = append(retBytes, EncodeBLSPublicKey(msg.ValidatorVotingPublicKey)...)
+	retBytes = append(retBytes, EncodeBLSPublicKey(msg.VotingPublicKey)...)
 
 	// BlockHash
 	if msg.BlockHash == nil {
@@ -98,16 +98,16 @@ func (msg *MsgDeSoValidatorVote) FromBytes(data []byte) error {
 	}
 	msg.MsgVersion = msgVersion
 
-	// ValidatorPublicKey
-	msg.ValidatorPublicKey, err = ReadPublicKey(rr)
+	// PublicKey
+	msg.PublicKey, err = ReadPublicKey(rr)
 	if err != nil {
-		return errors.Wrapf(err, "MsgDeSoValidatorVote.FromBytes: Error decoding ValidatorPublicKey")
+		return errors.Wrapf(err, "MsgDeSoValidatorVote.FromBytes: Error decoding PublicKey")
 	}
 
-	// ValidatorVotingPublicKey
-	msg.ValidatorVotingPublicKey, err = DecodeBLSPublicKey(rr)
+	// VotingPublicKey
+	msg.VotingPublicKey, err = DecodeBLSPublicKey(rr)
 	if err != nil {
-		return errors.Wrapf(err, "MsgDeSoValidatorVote.FromBytes: Error decoding ValidatorVotingPublicKey")
+		return errors.Wrapf(err, "MsgDeSoValidatorVote.FromBytes: Error decoding VotingPublicKey")
 	}
 
 	// BlockHash
@@ -141,13 +141,13 @@ type MsgDeSoValidatorTimeout struct {
 	// The ECDSA public key for the validator who constructed this timeout message.
 	// Given the validator's ECDSA public key, we can look up their Validator PKID.
 	// This allows us to verify that the timeout originated from a registered validator.
-	ValidatorPublicKey *PublicKey
+	PublicKey *PublicKey
 	// The BLS voting public key for the validator who constructed this timeout. The BLS
 	// public key is included in the timeout message because it allows us to easily
 	// verify that the BLS TimeoutPartialSignature is correctly formed, without having to
 	// first look up the validator's BLS public key in consensus. It helps optimize timeout
 	// message validation.
-	ValidatorVotingPublicKey *bls.PublicKey
+	VotingPublicKey *bls.PublicKey
 
 	// The view that the validator has timed out on.
 	TimedOutView uint64
@@ -178,17 +178,17 @@ func (msg *MsgDeSoValidatorTimeout) ToBytes(bool) ([]byte, error) {
 	// MsgVersion
 	retBytes = append(retBytes, msg.MsgVersion)
 
-	// ValidatorPublicKey
-	if msg.ValidatorPublicKey == nil {
-		return nil, errors.New("MsgDeSoValidatorTimeout.ToBytes: ValidatorPublicKey must not be nil")
+	// PublicKey
+	if msg.PublicKey == nil {
+		return nil, errors.New("MsgDeSoValidatorTimeout.ToBytes: PublicKey must not be nil")
 	}
-	retBytes = append(retBytes, msg.ValidatorPublicKey.ToBytes()...)
+	retBytes = append(retBytes, msg.PublicKey.ToBytes()...)
 
-	// ValidatorVotingPublicKey
-	if msg.ValidatorVotingPublicKey == nil {
-		return nil, errors.New("MsgDeSoValidatorTimeout.ToBytes: ValidatorVotingPublicKey must not be nil")
+	// VotingPublicKey
+	if msg.VotingPublicKey == nil {
+		return nil, errors.New("MsgDeSoValidatorTimeout.ToBytes: VotingPublicKey must not be nil")
 	}
-	retBytes = append(retBytes, EncodeBLSPublicKey(msg.ValidatorVotingPublicKey)...)
+	retBytes = append(retBytes, EncodeBLSPublicKey(msg.VotingPublicKey)...)
 
 	// TimeoutView
 	retBytes = append(retBytes, UintToBuf(msg.TimedOutView)...)
@@ -225,16 +225,16 @@ func (msg *MsgDeSoValidatorTimeout) FromBytes(data []byte) error {
 	}
 	msg.MsgVersion = msgVersion
 
-	// ValidatorPublicKey
-	msg.ValidatorPublicKey, err = ReadPublicKey(rr)
+	// PublicKey
+	msg.PublicKey, err = ReadPublicKey(rr)
 	if err != nil {
-		return errors.Wrapf(err, "MsgDeSoValidatorTimeout.FromBytes: Error decoding ValidatorPublicKey")
+		return errors.Wrapf(err, "MsgDeSoValidatorTimeout.FromBytes: Error decoding PublicKey")
 	}
 
-	// ValidatorVotingPublicKey
-	msg.ValidatorVotingPublicKey, err = DecodeBLSPublicKey(rr)
+	// VotingPublicKey
+	msg.VotingPublicKey, err = DecodeBLSPublicKey(rr)
 	if err != nil {
-		return errors.Wrapf(err, "MsgDeSoValidatorTimeout.FromBytes: Error decoding ValidatorVotingPublicKey")
+		return errors.Wrapf(err, "MsgDeSoValidatorTimeout.FromBytes: Error decoding VotingPublicKey")
 	}
 
 	// TimedOutView

--- a/lib/pos_network_test.go
+++ b/lib/pos_network_test.go
@@ -14,12 +14,12 @@ func TestValidatorVoteEncodeDecode(t *testing.T) {
 	validatorVotingPublicKey, votePartialSignature := _generateValidatorVotingPublicKeyAndSignature(t)
 
 	originalMsg := MsgDeSoValidatorVote{
-		MsgVersion:               MsgValidatorVoteVersion0,
-		ValidatorPublicKey:       &PublicKey{},
-		ValidatorVotingPublicKey: validatorVotingPublicKey,
-		BlockHash:                &BlockHash{},
-		ProposedInView:           9910,
-		VotePartialSignature:     votePartialSignature,
+		MsgVersion:           MsgValidatorVoteVersion0,
+		PublicKey:            &PublicKey{},
+		VotingPublicKey:      validatorVotingPublicKey,
+		BlockHash:            &BlockHash{},
+		ProposedInView:       9910,
+		VotePartialSignature: votePartialSignature,
 	}
 
 	// Encode the message and verify the length is correct.
@@ -34,8 +34,8 @@ func TestValidatorVoteEncodeDecode(t *testing.T) {
 
 	// Check that the message bodies are the same.
 	require.Equal(t, originalMsg.MsgVersion, decodedMsg.MsgVersion)
-	require.True(t, originalMsg.ValidatorPublicKey.Equal(*decodedMsg.ValidatorPublicKey))
-	require.True(t, originalMsg.ValidatorVotingPublicKey.Eq(decodedMsg.ValidatorVotingPublicKey))
+	require.True(t, originalMsg.PublicKey.Equal(*decodedMsg.PublicKey))
+	require.True(t, originalMsg.VotingPublicKey.Eq(decodedMsg.VotingPublicKey))
 	require.Equal(t, originalMsg.BlockHash, decodedMsg.BlockHash)
 	require.Equal(t, originalMsg.ProposedInView, decodedMsg.ProposedInView)
 	require.True(t, originalMsg.VotePartialSignature.Eq(decodedMsg.VotePartialSignature))
@@ -51,10 +51,10 @@ func TestValidatorTimeoutEncodeDecode(t *testing.T) {
 	require.NoError(t, err)
 
 	originalMsg := MsgDeSoValidatorTimeout{
-		MsgVersion:               MsgValidatorTimeoutVersion0,
-		ValidatorPublicKey:       &PublicKey{},
-		ValidatorVotingPublicKey: validatorVotingPublicKey,
-		TimedOutView:             999912,
+		MsgVersion:      MsgValidatorTimeoutVersion0,
+		PublicKey:       &PublicKey{},
+		VotingPublicKey: validatorVotingPublicKey,
+		TimedOutView:    999912,
 		HighQC: &QuorumCertificate{
 			BlockHash:      &BlockHash{},
 			ProposedInView: 999910,
@@ -78,8 +78,8 @@ func TestValidatorTimeoutEncodeDecode(t *testing.T) {
 
 	// Check that the message bodies are the same.
 	require.Equal(t, originalMsg.MsgVersion, decodedMsg.MsgVersion)
-	require.True(t, originalMsg.ValidatorPublicKey.Equal(*decodedMsg.ValidatorPublicKey))
-	require.True(t, originalMsg.ValidatorVotingPublicKey.Eq(decodedMsg.ValidatorVotingPublicKey))
+	require.True(t, originalMsg.PublicKey.Equal(*decodedMsg.PublicKey))
+	require.True(t, originalMsg.VotingPublicKey.Eq(decodedMsg.VotingPublicKey))
 	require.Equal(t, originalMsg.TimedOutView, decodedMsg.TimedOutView)
 	require.True(t, originalMsg.TimeoutPartialSignature.Eq(decodedMsg.TimeoutPartialSignature))
 


### PR DESCRIPTION
Simple PR that renames fields in the MsgValidatorVote and MsgValidatorTimeout message types. It renames:
- ValidatorPublicKey -> PublicKey
- ValidatorVotingPublicKey -> VotingPublicKey

The "Validator" prefix in the field names isn't needed in the field names since it's already contextualized in the message type.