### PR TITLE
PoS Add BLS public key and signature to BlockProducerInfo

### DIFF
--- a/lib/block_producer.go
+++ b/lib/block_producer.go
@@ -3,12 +3,13 @@ package lib
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/btcsuite/btcd/wire"
-	"github.com/tyler-smith/go-bip39"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/tyler-smith/go-bip39"
 
 	"github.com/deso-protocol/go-deadlock"
 
@@ -517,7 +518,7 @@ func (desoBlockProducer *DeSoBlockProducer) SignBlock(blockFound *MsgDeSoBlock) 
 
 	// Embed the signature into the block.
 	blockFound.BlockProducerInfo = &BlockProducerInfo{
-		PublicKey: desoBlockProducer.blockProducerPrivateKey.PubKey().SerializeCompressed(),
+		PublicKey: NewPublicKey(desoBlockProducer.blockProducerPrivateKey.PubKey().SerializeCompressed()),
 		Signature: signature,
 	}
 

--- a/lib/block_producer.go
+++ b/lib/block_producer.go
@@ -517,7 +517,7 @@ func (desoBlockProducer *DeSoBlockProducer) SignBlock(blockFound *MsgDeSoBlock) 
 	// If we get here, we now have a valid signature for the block.
 
 	// Embed the signature into the block.
-	blockFound.BlockProducerInfo = &BlockProducerInfo{
+	blockFound.BlockProducerInfo = &MsgDeSoBlockProducerInfo{
 		PublicKey: NewPublicKey(desoBlockProducer.blockProducerPrivateKey.PubKey().SerializeCompressed()),
 		Signature: signature,
 	}

--- a/lib/blockchain_test.go
+++ b/lib/blockchain_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
-	"github.com/go-pg/pg/v10"
 	"log"
 	"math/big"
 	"math/rand"
@@ -13,6 +11,9 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	"github.com/go-pg/pg/v10"
 
 	chainlib "github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec"
@@ -1652,11 +1653,11 @@ func TestBadBlockSignature(t *testing.T) {
 	// Since MineAndProcesssSingleBlock returns a valid block above, we can play with its
 	// signature and re-process the block to see what happens.
 	blockProducerInfoCopy := &BlockProducerInfo{Signature: &btcec.Signature{}}
-	blockProducerInfoCopy.PublicKey = append([]byte{}, finalBlock1.BlockProducerInfo.PublicKey...)
+	blockProducerInfoCopy.PublicKey = NewPublicKey(finalBlock1.BlockProducerInfo.PublicKey[:])
 	*blockProducerInfoCopy.Signature = *finalBlock1.BlockProducerInfo.Signature
 
 	// A bad signature with the right public key should fail.
-	finalBlock1.BlockProducerInfo.PublicKey = senderPkBytes
+	finalBlock1.BlockProducerInfo.PublicKey = NewPublicKey(senderPkBytes)
 	_, _, err = chain.ProcessBlock(finalBlock1, true)
 	require.Error(err)
 	require.Contains(err.Error(), RuleErrorInvalidBlockProducerSIgnature)
@@ -1664,7 +1665,7 @@ func TestBadBlockSignature(t *testing.T) {
 	// A signature that's outright missing should fail
 	blockSignerPkBytes, _, err := Base58CheckDecode(blockSignerPk)
 	require.NoError(err)
-	finalBlock1.BlockProducerInfo.PublicKey = blockSignerPkBytes
+	finalBlock1.BlockProducerInfo.PublicKey = NewPublicKey(blockSignerPkBytes)
 	finalBlock1.BlockProducerInfo.Signature = nil
 	_, _, err = chain.ProcessBlock(finalBlock1, true)
 	require.Error(err)

--- a/lib/blockchain_test.go
+++ b/lib/blockchain_test.go
@@ -1652,7 +1652,7 @@ func TestBadBlockSignature(t *testing.T) {
 
 	// Since MineAndProcesssSingleBlock returns a valid block above, we can play with its
 	// signature and re-process the block to see what happens.
-	blockProducerInfoCopy := &BlockProducerInfo{Signature: &btcec.Signature{}}
+	blockProducerInfoCopy := &MsgDeSoBlockProducerInfo{Signature: &btcec.Signature{}}
 	blockProducerInfoCopy.PublicKey = NewPublicKey(finalBlock1.BlockProducerInfo.PublicKey[:])
 	*blockProducerInfoCopy.Signature = *finalBlock1.BlockProducerInfo.Signature
 

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -140,6 +140,22 @@ const (
 	MsgValidatorTimeoutVersion0 MsgValidatorTimeoutVersion = 0
 )
 
+// Versioning for the BlockProducerInfo field included in MsgDeSoBlock. This type alias
+// is equivalent to a uint8, and supports the same byte encoders/decoders.
+type BlockProducerInfoVersion = byte
+
+const (
+	// This represents the original schema for the BlockProducerInfo field included in
+	// Proof of Work blocks. The original schema  did not have versioning, so we use a default
+	// version value of 0 to denote this. The original schema only contains the block producer's
+	// ECDSA public key and ECDSA signature of the block.
+	BlockProducerInfoVersion0 BlockProducerInfoVersion = 0
+	// This version is introduced starting with Proof of Stake blocks. It adds versioning to the
+	// BlockProducerInfo schema, and adds two new fields for the block producer's BLS public key
+	// and BLS partial signature for the block.
+	BlockProducerInfoVersion1 BlockProducerInfoVersion = 1
+)
+
 var (
 	MaxUint256, _ = uint256.FromHex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -142,18 +142,18 @@ const (
 
 // Versioning for the BlockProducerInfo field included in MsgDeSoBlock. This type alias
 // is equivalent to a uint8, and supports the same byte encoders/decoders.
-type BlockProducerInfoVersion = byte
+type MsgDeSoBlockProducerInfoVersion = byte
 
 const (
 	// This represents the original schema for the BlockProducerInfo field included in
 	// Proof of Work blocks. The original schema  did not have versioning, so we use a default
 	// version value of 0 to denote this. The original schema only contains the block producer's
 	// ECDSA public key and ECDSA signature of the block.
-	BlockProducerInfoVersion0 BlockProducerInfoVersion = 0
+	MsgDeSoBlockProducerInfoVersion0 MsgDeSoBlockProducerInfoVersion = 0
 	// This version is introduced starting with Proof of Stake blocks. It adds versioning to the
 	// BlockProducerInfo schema, and adds two new fields for the block producer's BLS public key
 	// and BLS partial signature for the block.
-	BlockProducerInfoVersion1 BlockProducerInfoVersion = 1
+	MsgDeSoBlockProducerInfoVersion1 MsgDeSoBlockProducerInfoVersion = 1
 )
 
 var (

--- a/lib/network.go
+++ b/lib/network.go
@@ -2409,7 +2409,7 @@ func (bpi *BlockProducerInfo) ToBytes() ([]byte, error) {
 
 // Byte decoder for the BlockProducerInfo, with support for versioning. The encoder only
 // supports BlockProducerInfo version 1 and above. For the legacy version 0, use the
-// BlockProducerInfo.Serialize_Legacy() method instead.
+// BlockProducerInfo.Deserialize_Legacy() method instead.
 func (bpi *BlockProducerInfo) FromBytes(rr *bytes.Reader) error {
 	var err error
 
@@ -2417,6 +2417,12 @@ func (bpi *BlockProducerInfo) FromBytes(rr *bytes.Reader) error {
 	bpi.Version, err = rr.ReadByte()
 	if err != nil {
 		return errors.Wrapf(err, "BlockProducerInfo.FromBytes: Problem reading Version")
+	}
+
+	// If we see version 0 here, we know the BlockProducerInfo is malformed. The new byte encoder
+	// cannot have produced this byte encoding.
+	if bpi.Version == BlockProducerInfoVersion0 {
+		return fmt.Errorf("BlockProducerInfo.FromBytes: BlockProducerInfo version 0 not supported")
 	}
 
 	// Required ECDSA PublicKey
@@ -2542,11 +2548,11 @@ type MsgDeSoBlock struct {
 	// who they accept blocks from.
 	//
 	// In Proof of Stake blocks, this field is required and serves two purposes:
-	// 1. It's allows the block producer to sign their block with their ECDSA or BLS private key.
+	// 1. It allows the block producer to sign its block with its ECDSA or BLS private key.
 	// This allows validators to verify that the block was produced by the expected leader for the
 	// current block height and view.
 	// 2. It contains the block producer's BLS partial signature, which acts as their vote on the
-	// block. This way, their vote can be aggregated into a QC by the next block proposer in the leader
+	// block. This way, its vote can be aggregated into a QC by the next block proposer in the leader
 	// schedule.
 	BlockProducerInfo *BlockProducerInfo
 }

--- a/lib/network.go
+++ b/lib/network.go
@@ -2442,7 +2442,7 @@ type MsgDeSoBlock struct {
 	Header *MsgDeSoHeader
 	Txns   []*MsgDeSoTxn
 
-	// This BlockProducerInfo field describes the proposer for the block and their signature
+	// This BlockProducerInfo field describes the producer of the block and their signature
 	// for the block.
 	//
 	// In Proof of Work blocks, this field is optional and provides the producer of the block

--- a/lib/network.go
+++ b/lib/network.go
@@ -2374,9 +2374,10 @@ type BlockProducerInfo struct {
 // supports BlockProducerInfo version 1 and above. For the legacy version 0, use the
 // BlockProducerInfo.Serialize_Legacy() method instead.
 func (bpi *BlockProducerInfo) ToBytes() ([]byte, error) {
-	// BlockProducerInfo version 0 is not supported.
-	if bpi.Version == BlockProducerInfoVersion0 {
-		return nil, fmt.Errorf("BlockProducerInfo.ToBytes: BlockProducerInfo version 0 not supported")
+	// Only support byte encoding for BlockProducerInfo version 1. All later versions will
+	// need custom encoding.
+	if bpi.Version != BlockProducerInfoVersion1 {
+		return nil, fmt.Errorf("BlockProducerInfo.ToBytes: BlockProducerInfo version %d not supported", bpi.Version)
 	}
 
 	encodedBytes := []byte{}
@@ -2419,10 +2420,10 @@ func (bpi *BlockProducerInfo) FromBytes(rr *bytes.Reader) error {
 		return errors.Wrapf(err, "BlockProducerInfo.FromBytes: Problem reading Version")
 	}
 
-	// If we see version 0 here, we know the BlockProducerInfo is malformed. The new byte encoder
-	// cannot have produced this byte encoding.
-	if bpi.Version == BlockProducerInfoVersion0 {
-		return fmt.Errorf("BlockProducerInfo.FromBytes: BlockProducerInfo version 0 not supported")
+	// Only support byte decoding for BlockProducerInfo version 1. All later versions will
+	// need custom decoding.
+	if bpi.Version != BlockProducerInfoVersion1 {
+		return fmt.Errorf("BlockProducerInfo.FromBytes: BlockProducerInfo version %d not supported", bpi.Version)
 	}
 
 	// Required ECDSA PublicKey

--- a/lib/network.go
+++ b/lib/network.go
@@ -2351,33 +2351,33 @@ func (msg *MsgDeSoHeader) String() string {
 // BLOCK Message
 // ==================================================================
 
-type BlockProducerInfo struct {
-	Version BlockProducerInfoVersion
+type MsgDeSoBlockProducerInfo struct {
+	Version MsgDeSoBlockProducerInfoVersion
 
 	// ECDSA public key for the block producer.
 	PublicKey *PublicKey
 	// The block producer's ECDSA signature for the block. This field is used in
-	// BlockProducerInfo version 0, and is deprecated from version 1 onwards.
+	// MsgDeSoBlockProducerInfo version 0, and is deprecated from version 1 onwards.
 	Signature *btcec.Signature
 
 	// The BLS public key of the validator who constructed this block. This field is
-	// populated starting in BlockProducerInfo version 1.
+	// populated starting in MsgDeSoBlockProducerInfo version 1.
 	VotingPublicKey *bls.PublicKey
 	// The validator's partial BLS signature of the (ProposedInView, BlockHash) pair
 	// for enclosing block. This signature proves the validator proposed the block,
 	// and also acts as the validator's vote for this block. This filed is only populated
-	// starting in BlockProducerInfo version 1.
+	// starting in MsgDeSoBlockProducerInfo version 1.
 	VotePartialSignature *bls.Signature
 }
 
-// Byte encoder for the BlockProducerInfo with support for versioning. The encoder only
-// supports BlockProducerInfo version 1 and above. For the legacy version 0, use the
-// BlockProducerInfo.Serialize_Legacy() method instead.
-func (bpi *BlockProducerInfo) ToBytes() ([]byte, error) {
+// Byte encoder for the MsgDeSoBlockProducerInfo with support for versioning. The encoder only
+// supports MsgDeSoBlockProducerInfo version 1 and above. For the legacy version 0, use the
+// MsgDeSoBlockProducerInfo.Serialize_Legacy() method instead.
+func (bpi *MsgDeSoBlockProducerInfo) ToBytes() ([]byte, error) {
 	// Only support byte encoding for BlockProducerInfo version 1. All later versions will
 	// need custom encoding.
-	if bpi.Version != BlockProducerInfoVersion1 {
-		return nil, fmt.Errorf("BlockProducerInfo.ToBytes: BlockProducerInfo version %d not supported", bpi.Version)
+	if bpi.Version != MsgDeSoBlockProducerInfoVersion1 {
+		return nil, fmt.Errorf("MsgDeSoBlockProducerInfo.ToBytes: BlockProducerInfo version %d not supported", bpi.Version)
 	}
 
 	encodedBytes := []byte{}
@@ -2387,73 +2387,73 @@ func (bpi *BlockProducerInfo) ToBytes() ([]byte, error) {
 
 	// Required ECDSA PublicKey
 	if bpi.PublicKey == nil {
-		return nil, fmt.Errorf("BlockProducerInfo.ToBytes: PublicKey is required")
+		return nil, fmt.Errorf("MsgDeSoBlockProducerInfo.ToBytes: PublicKey is required")
 	}
 	encodedBytes = append(encodedBytes, bpi.PublicKey.ToBytes()...)
 
-	// The ECDSA Signature is redundant, and is removed in BlockProducerInfo version 1 and above
+	// The ECDSA Signature is redundant, and is removed in MsgDeSoBlockProducerInfo version 1 and above
 
 	// Voting BLS PublicKey
 	if bpi.VotingPublicKey == nil {
-		return nil, fmt.Errorf("BlockProducerInfo.ToBytes: VotingPublicKey is required")
+		return nil, fmt.Errorf("MsgDeSoBlockProducerInfo.ToBytes: VotingPublicKey is required")
 	}
 	encodedBytes = append(encodedBytes, EncodeByteArray(bpi.VotingPublicKey.ToBytes())...)
 
 	// Vote BLS Partial Signature
 	if bpi.VotePartialSignature == nil {
-		return nil, fmt.Errorf("BlockProducerInfo.ToBytes: VotePartialSignature is required")
+		return nil, fmt.Errorf("MsgDeSoBlockProducerInfo.ToBytes: VotePartialSignature is required")
 	}
 	encodedBytes = append(encodedBytes, EncodeByteArray(bpi.VotePartialSignature.ToBytes())...)
 
 	return encodedBytes, nil
 }
 
-// Byte decoder for the BlockProducerInfo, with support for versioning. The encoder only
-// supports BlockProducerInfo version 1 and above. For the legacy version 0, use the
-// BlockProducerInfo.Deserialize_Legacy() method instead.
-func (bpi *BlockProducerInfo) FromBytes(rr *bytes.Reader) error {
+// Byte decoder for the MsgDeSoBlockProducerInfo, with support for versioning. The encoder only
+// supports MsgDeSoBlockProducerInfo version 1 and above. For the legacy version 0, use the
+// MsgDeSoBlockProducerInfo.Deserialize_Legacy() method instead.
+func (bpi *MsgDeSoBlockProducerInfo) FromBytes(rr *bytes.Reader) error {
 	var err error
 
 	// Required Version field
 	bpi.Version, err = rr.ReadByte()
 	if err != nil {
-		return errors.Wrapf(err, "BlockProducerInfo.FromBytes: Problem reading Version")
+		return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.FromBytes: Problem reading Version")
 	}
 
 	// Only support byte decoding for BlockProducerInfo version 1. All later versions will
 	// need custom decoding.
-	if bpi.Version != BlockProducerInfoVersion1 {
-		return fmt.Errorf("BlockProducerInfo.FromBytes: BlockProducerInfo version %d not supported", bpi.Version)
+	if bpi.Version != MsgDeSoBlockProducerInfoVersion1 {
+		return fmt.Errorf("MsgDeSoBlockProducerInfo.FromBytes: BlockProducerInfo version %d not supported", bpi.Version)
 	}
 
 	// Required ECDSA PublicKey
 	bpi.PublicKey, err = ReadPublicKey(rr)
 	if err != nil {
-		return errors.Wrapf(err, "BlockProducerInfo.FromBytes: Problem reading PublicKey")
+		return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.FromBytes: Problem reading PublicKey")
 	}
 
-	// The ECDSA Signature is redundant, and is removed in BlockProducerInfo version 1 and above
+	// The ECDSA Signature is redundant, and is removed in MsgDeSoBlockProducerInfo version 1 and above
 	// so we skip it here.
 
 	// Voting BLS PublicKey
 	bpi.VotingPublicKey, err = DecodeBLSPublicKey(rr)
 	if err != nil {
-		return errors.Wrapf(err, "BlockProducerInfo.FromBytes: Problem reading VotingPublicKey")
+		return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.FromBytes: Problem reading VotingPublicKey")
 	}
 
 	// Vote BLS Partial Signature
 	bpi.VotePartialSignature, err = DecodeBLSSignature(rr)
 	if err != nil {
-		return errors.Wrapf(err, "BlockProducerInfo.FromBytes: Problem reading VotePartialSignature")
+		return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.FromBytes: Problem reading VotePartialSignature")
 	}
 
 	return nil
 }
 
-// Legacy byte encoder for BlockProducerInfo with no support for versioning.
+// Legacy byte encoder for MsgDeSoBlockProducerInfo with no support for versioning.
 // It encodes just the public key and signature according to the legacy encoding
 // format.
-func (bpi *BlockProducerInfo) Serialize_Legacy() []byte {
+func (bpi *MsgDeSoBlockProducerInfo) Serialize_Legacy() []byte {
 	data := []byte{}
 	data = append(data, UintToBuf(uint64(len(bpi.PublicKey)))...)
 	data = append(data, bpi.PublicKey.ToBytes()...)
@@ -2468,28 +2468,28 @@ func (bpi *BlockProducerInfo) Serialize_Legacy() []byte {
 	return data
 }
 
-// Legacy byte decoder for BlockProducerInfo with no support for versioning.
+// Legacy byte decoder for MsgDeSoBlockProducerInfo with no support for versioning.
 // It decodes the public key and signature according to the legacy encoding
 // format and then sets the version to 0.
-func (bpi *BlockProducerInfo) Deserialize_Legacy(data []byte) error {
-	ret := &BlockProducerInfo{}
+func (bpi *MsgDeSoBlockProducerInfo) Deserialize_Legacy(data []byte) error {
+	ret := &MsgDeSoBlockProducerInfo{}
 	rr := bytes.NewReader(data)
 
 	// Set the version to 0 since this is the legacy format.
-	ret.Version = BlockProducerInfoVersion0
+	ret.Version = MsgDeSoBlockProducerInfoVersion0
 
 	// De-serialize the public key.
 	{
 		pkLen, err := ReadUvarint(rr)
 		if err != nil {
-			return errors.Wrapf(err, "BlockProducerInfo.Deserialize: Error reading public key len")
+			return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.Deserialize: Error reading public key len")
 		}
 		if pkLen > MaxMessagePayload {
-			return errors.Wrapf(err, "BlockProducerInfo.Deserialize: pkLen too long: %v", pkLen)
+			return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.Deserialize: pkLen too long: %v", pkLen)
 		}
 		ret.PublicKey, err = ReadPublicKey(rr)
 		if err != nil {
-			return errors.Wrapf(err, "BlockProducerInfo.Deserialize: Error reading public key: ")
+			return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.Deserialize: Error reading public key: ")
 		}
 	}
 
@@ -2497,18 +2497,18 @@ func (bpi *BlockProducerInfo) Deserialize_Legacy(data []byte) error {
 	{
 		sigLen, err := ReadUvarint(rr)
 		if err != nil {
-			return errors.Wrapf(err, "BlockProducerInfo.Deserialize: Error reading signature len")
+			return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.Deserialize: Error reading signature len")
 		}
 		if sigLen > MaxMessagePayload {
-			return errors.Wrapf(err, "BlockProducerInfo.Deserialize: signature len too long: %v", sigLen)
+			return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.Deserialize: signature len too long: %v", sigLen)
 		}
 		sigBytes, err := SafeMakeSliceWithLength[byte](sigLen)
 		if err != nil {
-			return errors.Wrapf(err, "BlockProducerInfo.Deserialize: Problem making slice for sigBytes")
+			return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.Deserialize: Problem making slice for sigBytes")
 		}
 		_, err = io.ReadFull(rr, sigBytes)
 		if err != nil {
-			return errors.Wrapf(err, "BlockProducerInfo.Deserialize: Error reading signature: ")
+			return errors.Wrapf(err, "MsgDeSoBlockProducerInfo.Deserialize: Error reading signature: ")
 		}
 		ret.Signature = nil
 		if sigLen > 0 {
@@ -2524,7 +2524,7 @@ func (bpi *BlockProducerInfo) Deserialize_Legacy(data []byte) error {
 	return nil
 }
 
-func (bpi *BlockProducerInfo) String() string {
+func (bpi *MsgDeSoBlockProducerInfo) String() string {
 	if bpi == nil || len(bpi.PublicKey) == 0 {
 		return "Signer Key: NONE"
 	}
@@ -2535,7 +2535,7 @@ type MsgDeSoBlock struct {
 	Header *MsgDeSoHeader
 	Txns   []*MsgDeSoTxn
 
-	// This BlockProducerInfo field describes the producer of the block and their signature
+	// This MsgDeSoBlockProducerInfo field describes the producer of the block and their signature
 	// for the block.
 	//
 	// In Proof of Work blocks, this field is optional and provides the producer of the block
@@ -2550,7 +2550,7 @@ type MsgDeSoBlock struct {
 	// 2. It contains the block producer's BLS partial signature, which acts as their vote on the
 	// block. This way, its vote can be aggregated into a QC by the next block proposer in the leader
 	// schedule.
-	BlockProducerInfo *BlockProducerInfo
+	BlockProducerInfo *MsgDeSoBlockProducerInfo
 }
 
 func (msg *MsgDeSoBlock) EncodeBlockCommmon(preSignature bool) ([]byte, error) {
@@ -2706,7 +2706,7 @@ func (msg *MsgDeSoBlock) FromBytes(data []byte) error {
 
 	if ret.Header.Version == HeaderVersion1 {
 		// All version 1 blocks have an optional BlockProducerInfo attached.
-		var blockProducerInfo *BlockProducerInfo
+		var blockProducerInfo *MsgDeSoBlockProducerInfo
 		if blockProducerInfoLen > 0 {
 			if blockProducerInfoLen > MaxMessagePayload {
 				return fmt.Errorf("MsgDeSoBlock.FromBytes: Header length %d longer "+
@@ -2720,7 +2720,7 @@ func (msg *MsgDeSoBlock) FromBytes(data []byte) error {
 			if err != nil {
 				return errors.Wrapf(err, "MsgDeSoBlock.FromBytes: Problem reading header")
 			}
-			blockProducerInfo = &BlockProducerInfo{}
+			blockProducerInfo = &MsgDeSoBlockProducerInfo{}
 			if err = blockProducerInfo.Deserialize_Legacy(blockProducerInfoBytes); err != nil {
 				return errors.Wrapf(err, "MsgDeSoBlock.FromBytes: Error deserializing block producer info")
 			}
@@ -2741,7 +2741,7 @@ func (msg *MsgDeSoBlock) FromBytes(data []byte) error {
 			return fmt.Errorf("MsgDeSoBlock.FromBytes: BlockProducerInfo length cannot be zero")
 		}
 
-		blockProducerInfo := &BlockProducerInfo{}
+		blockProducerInfo := &MsgDeSoBlockProducerInfo{}
 		if blockProducerInfo.FromBytes(rr); err != nil {
 			return errors.Wrapf(err, "MsgDeSoBlock.FromBytes: Error decoding BlockProducerInfo")
 		}

--- a/lib/network_test.go
+++ b/lib/network_test.go
@@ -162,6 +162,17 @@ func createTestBlockHeaderVersion2(t *testing.T) *MsgDeSoHeader {
 	}
 }
 
+func createTestBlockProducerInfoVersion1(t *testing.T) *BlockProducerInfo {
+	testBLSPublicKey, testBLSSignature := _generateValidatorVotingPublicKeyAndSignature(t)
+
+	return &BlockProducerInfo{
+		Version:              1,
+		PublicKey:            pkForTesting1,
+		VotingPublicKey:      testBLSPublicKey,
+		VotePartialSignature: testBLSSignature,
+	}
+}
+
 func TestHeaderConversionAndReadWriteMessage(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -484,6 +495,30 @@ var expectedV0Header = &MsgDeSoHeader{
 	TstampSecs: uint64(0x70717273),
 	Height:     uint64(99999),
 	Nonce:      uint64(123456),
+}
+
+func TestSerializeBlockVersion2(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	_ = assert
+	_ = require
+
+	originalBlock := &MsgDeSoBlock{
+		Header:            createTestBlockHeaderVersion2(t),
+		BlockProducerInfo: createTestBlockProducerInfoVersion1(t),
+	}
+
+	encodedBytes, err := originalBlock.ToBytes(false)
+	require.NoError(err)
+
+	decodedBlock := NewMessage(MsgTypeBlock).(*MsgDeSoBlock)
+	err = decodedBlock.FromBytes(encodedBytes)
+	require.NoError(err)
+
+	assert.Equal(originalBlock.Header.Version, decodedBlock.Header.Version)
+	assert.Equal(originalBlock.BlockProducerInfo.PublicKey, decodedBlock.BlockProducerInfo.PublicKey)
+	assert.True(originalBlock.BlockProducerInfo.VotingPublicKey.Eq(decodedBlock.BlockProducerInfo.VotingPublicKey))
+	assert.True(originalBlock.BlockProducerInfo.VotePartialSignature.Eq(decodedBlock.BlockProducerInfo.VotePartialSignature))
 }
 
 func TestBlockSerialize(t *testing.T) {

--- a/lib/network_test.go
+++ b/lib/network_test.go
@@ -162,10 +162,10 @@ func createTestBlockHeaderVersion2(t *testing.T) *MsgDeSoHeader {
 	}
 }
 
-func createTestBlockProducerInfoVersion1(t *testing.T) *BlockProducerInfo {
+func createTestBlockProducerInfoVersion1(t *testing.T) *MsgDeSoBlockProducerInfo {
 	testBLSPublicKey, testBLSSignature := _generateValidatorVotingPublicKeyAndSignature(t)
 
-	return &BlockProducerInfo{
+	return &MsgDeSoBlockProducerInfo{
 		Version:              1,
 		PublicKey:            NewPublicKey(pkForTesting1),
 		VotingPublicKey:      testBLSPublicKey,
@@ -338,7 +338,7 @@ var expectedBlock = &MsgDeSoBlock{
 	Header: expectedBlockHeaderVersion1,
 	Txns:   expectedTransactions(true), // originally was effectively false
 
-	BlockProducerInfo: &BlockProducerInfo{
+	BlockProducerInfo: &MsgDeSoBlockProducerInfo{
 		PublicKey: NewPublicKey([]byte{
 			// random bytes
 			0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x30,

--- a/lib/network_test.go
+++ b/lib/network_test.go
@@ -167,7 +167,7 @@ func createTestBlockProducerInfoVersion1(t *testing.T) *BlockProducerInfo {
 
 	return &BlockProducerInfo{
 		Version:              1,
-		PublicKey:            pkForTesting1,
+		PublicKey:            NewPublicKey(pkForTesting1),
 		VotingPublicKey:      testBLSPublicKey,
 		VotePartialSignature: testBLSSignature,
 	}
@@ -339,13 +339,13 @@ var expectedBlock = &MsgDeSoBlock{
 	Txns:   expectedTransactions(true), // originally was effectively false
 
 	BlockProducerInfo: &BlockProducerInfo{
-		PublicKey: []byte{
+		PublicKey: NewPublicKey([]byte{
 			// random bytes
 			0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x30,
 			0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x10,
 			0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x30,
 			0x21, 0x22, 0x23,
-		},
+		}),
 	},
 }
 

--- a/lib/server.go
+++ b/lib/server.go
@@ -1795,7 +1795,8 @@ func (srv *Server) _handleBlock(pp *Peer, blk *MsgDeSoBlock) {
 	if len(srv.blockchain.trustedBlockProducerPublicKeys) > 0 && blockHeader.Height >= srv.blockchain.trustedBlockProducerStartHeight {
 		if blk.BlockProducerInfo != nil {
 			_, entryExists := srv.mempool.readOnlyUtxoView.ForbiddenPubKeyToForbiddenPubKeyEntry[MakePkMapKey(
-				blk.BlockProducerInfo.PublicKey)]
+				blk.BlockProducerInfo.PublicKey.ToBytes(),
+			)]
 			if entryExists {
 				srv._logAndDisconnectPeer(pp, blk, "Got forbidden block signature public key.")
 				return


### PR DESCRIPTION
This PR makes three changes:
1. It migrates the existing ECDSA PublicKey fields in the BlockProducerInfo from a byte slice to the strongly typed `PublicKey` type
2. It introduces versioning to BlockProducerInfo, with a byte encoder and decoder that support the new versioned schema. The existing un-versioned schema is still supported by the legacy encoder and decoder
3. It adds BLS VotingPUblicKey and VotePartialSignature fields to BlockProducerInfo that are populated in newly created Version=1 format