### PR TITLE
Fix copy paste mistake in function comment

### DIFF
--- a/integration_testing/tools.go
+++ b/integration_testing/tools.go
@@ -399,7 +399,8 @@ func listenForBlockHeight(t *testing.T, node *cmd.Node, height uint32, signal ch
 	}()
 }
 
-// listenForBlockHeight busy-waits until the node's block tip reaches provided height.
+// disconnectAtBlockHeight busy-waits until the node's block tip reaches provided height, and then disconnects
+// from the provided bridge.
 func disconnectAtBlockHeight(t *testing.T, syncingNode *cmd.Node, bridge *ConnectionBridge, height uint32) {
 	listener := make(chan bool)
 	listenForBlockHeight(t, syncingNode, height, listener)


### PR DESCRIPTION
This commit writes a comment for `disconnectAtBlockHeight` that more closely matches what it does.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
