### PR TITLE
PoS Rename SnapshotValidatorEntries to SnapshotValidatorSet

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -140,7 +140,7 @@ type UtxoView struct {
 	// SnapshotValidatorSet is a map of <SnapshotAtEpochNumber, ValidatorPKID> to a ValidatorEntry.
 	// It contains the snapshot value of every ValidatorEntry that makes up the validator set at
 	// the given SnapshotAtEpochNumber.
-	SnapshotValidatorSet map[SnapshotValidatorMapKey]*ValidatorEntry
+	SnapshotValidatorSet map[SnapshotValidatorSetMapKey]*ValidatorEntry
 
 	// SnapshotGlobalActiveStakeAmountNanos is a map of SnapshotAtEpochNumber to a GlobalActiveStakeAmountNanos.
 	// It contains the snapshot value of the GlobalActiveStakeAmountNanos at the given SnapshotAtEpochNumber.
@@ -261,7 +261,7 @@ func (bav *UtxoView) _ResetViewMappingsAfterFlush() {
 	bav.SnapshotGlobalParamEntries = make(map[uint64]*GlobalParamsEntry)
 
 	// SnapshotValidatorSet
-	bav.SnapshotValidatorSet = make(map[SnapshotValidatorMapKey]*ValidatorEntry)
+	bav.SnapshotValidatorSet = make(map[SnapshotValidatorSetMapKey]*ValidatorEntry)
 
 	// SnapshotGlobalActiveStakeAmountNanos
 	bav.SnapshotGlobalActiveStakeAmountNanos = make(map[uint64]*uint256.Int)

--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -137,9 +137,10 @@ type UtxoView struct {
 	// It contains the snapshot value of the GlobalParamsEntry at the given SnapshotAtEpochNumber.
 	SnapshotGlobalParamEntries map[uint64]*GlobalParamsEntry
 
-	// SnapshotValidatorEntries is a map of <SnapshotAtEpochNumber, ValidatorPKID> to a ValidatorEntry.
-	// It contains the snapshot value of a ValidatorEntry at the given SnapshotAtEpochNumber.
-	SnapshotValidatorEntries map[SnapshotValidatorMapKey]*ValidatorEntry
+	// SnapshotValidatorSet is a map of <SnapshotAtEpochNumber, ValidatorPKID> to a ValidatorEntry.
+	// It contains the snapshot value of every ValidatorEntry that makes up the validator set at
+	// the given SnapshotAtEpochNumber.
+	SnapshotValidatorSet map[SnapshotValidatorMapKey]*ValidatorEntry
 
 	// SnapshotGlobalActiveStakeAmountNanos is a map of SnapshotAtEpochNumber to a GlobalActiveStakeAmountNanos.
 	// It contains the snapshot value of the GlobalActiveStakeAmountNanos at the given SnapshotAtEpochNumber.
@@ -259,8 +260,8 @@ func (bav *UtxoView) _ResetViewMappingsAfterFlush() {
 	// SnapshotGlobalParamEntries
 	bav.SnapshotGlobalParamEntries = make(map[uint64]*GlobalParamsEntry)
 
-	// SnapshotValidatorEntries
-	bav.SnapshotValidatorEntries = make(map[SnapshotValidatorMapKey]*ValidatorEntry)
+	// SnapshotValidatorSet
+	bav.SnapshotValidatorSet = make(map[SnapshotValidatorMapKey]*ValidatorEntry)
 
 	// SnapshotGlobalActiveStakeAmountNanos
 	bav.SnapshotGlobalActiveStakeAmountNanos = make(map[uint64]*uint256.Int)
@@ -559,9 +560,9 @@ func (bav *UtxoView) CopyUtxoView() (*UtxoView, error) {
 		newView.SnapshotGlobalParamEntries[epochNumber] = globalParamsEntry.Copy()
 	}
 
-	// Copy the SnapshotValidatorEntries
-	for mapKey, validatorEntry := range bav.SnapshotValidatorEntries {
-		newView.SnapshotValidatorEntries[mapKey] = validatorEntry.Copy()
+	// Copy the SnapshotValidatorSet
+	for mapKey, validatorEntry := range bav.SnapshotValidatorSet {
+		newView.SnapshotValidatorSet[mapKey] = validatorEntry.Copy()
 	}
 
 	// Copy the SnapshotGlobalActiveStakeAmountNanos

--- a/lib/block_view_flush.go
+++ b/lib/block_view_flush.go
@@ -2,11 +2,12 @@ package lib
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/dgraph-io/badger/v3"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"reflect"
 )
 
 func (bav *UtxoView) FlushToDb(blockHeight uint64) error {
@@ -164,7 +165,7 @@ func (bav *UtxoView) FlushToDbWithTxn(txn *badger.Txn, blockHeight uint64) error
 	if err := bav._flushSnapshotGlobalParamsEntryToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}
-	if err := bav._flushSnapshotValidatorEntriesToDbWithTxn(txn, blockHeight); err != nil {
+	if err := bav._flushSnapshotValidatorSetToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}
 	if err := bav._flushSnapshotGlobalActiveStakeAmountNanosToDbWithTxn(txn, blockHeight); err != nil {

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -533,14 +533,16 @@ type DBPrefixes struct {
 	// Prefix, <SnapshotAtEpochNumber uint64> -> *GlobalParamsEntry
 	PrefixSnapshotGlobalParamsEntry []byte `prefix_id:"[85]" is_state:"true"`
 
-	// PrefixSnapshotValidatorByPKID: Retrieve a snapshot ValidatorEntry by <SnapshotAtEpochNumber, PKID>.
+	// PrefixSnapshotValidatorSetByPKID: Retrieve a ValidatorEntry from a snapshot validator set by
+	// <SnapshotAtEpochNumber, PKID>.
 	// Prefix, <SnapshotAtEpochNumber uint64>, <ValidatorPKID [33]byte> -> *ValidatorEntry
-	PrefixSnapshotValidatorByPKID []byte `prefix_id:"[86]" is_state:"true"`
+	PrefixSnapshotValidatorSetByPKID []byte `prefix_id:"[86]" is_state:"true"`
 
-	// PrefixSnapshotValidatorByStatusAndStake: Retrieve stake-ordered active ValidatorEntries by SnapshotAtEpochNumber.
+	// PrefixSnapshotValidatorSetByStake: Retrieve stake-ordered ValidatorEntries from a snapshot validator set
+	// by SnapshotAtEpochNumber.
 	// Prefix, <SnapshotAtEpochNumber uint64>, <TotalStakeAmountNanos *uint256.Int>, <ValidatorPKID [33]byte> -> nil
 	// Note: we parse the ValidatorPKID from the key and the value is nil to save space.
-	PrefixSnapshotValidatorByStake []byte `prefix_id:"[87]" is_state:"true"`
+	PrefixSnapshotValidatorSetByStake []byte `prefix_id:"[87]" is_state:"true"`
 
 	// PrefixSnapshotGlobalActiveStakeAmountNanos: Retrieve a snapshot GlobalActiveStakeAmountNanos by SnapshotAtEpochNumber.
 	// Prefix, <SnapshotAtEpochNumber uint64> -> *uint256.Int
@@ -776,10 +778,10 @@ func StatePrefixToDeSoEncoder(prefix []byte) (_isEncoder bool, _encoder DeSoEnco
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotGlobalParamsEntry) {
 		// prefix_id:"[85]"
 		return true, &GlobalParamsEntry{}
-	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorByPKID) {
+	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorSetByPKID) {
 		// prefix_id:"[86]"
 		return true, &ValidatorEntry{}
-	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorByStake) {
+	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorSetByStake) {
 		// prefix_id:"[87]"
 		return false, nil
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotGlobalActiveStakeAmountNanos) {

--- a/lib/pos_epoch_complete_hook.go
+++ b/lib/pos_epoch_complete_hook.go
@@ -80,7 +80,7 @@ func (bav *UtxoView) RunEpochCompleteHook(blockHeight uint64) error {
 		return errors.Wrapf(err, "RunEpochCompleteHook: error retrieving top ValidatorEntries: ")
 	}
 	for _, validatorEntry := range validatorSet {
-		bav._setSnapshotValidatorEntry(validatorEntry, currentEpochEntry.EpochNumber)
+		bav._setSnapshotValidatorSetEntry(validatorEntry, currentEpochEntry.EpochNumber)
 	}
 
 	// Snapshot the current GlobalActiveStakeAmountNanos.

--- a/lib/pos_epoch_complete_hook_test.go
+++ b/lib/pos_epoch_complete_hook_test.go
@@ -149,9 +149,9 @@ func TestRunEpochCompleteHook(t *testing.T) {
 	_assertEmptyValidatorSnapshots := func() {
 		// Test SnapshotValidatorByPKID is nil.
 		for _, pkid := range validatorPKIDs {
-			snapshotValidatorEntry, err := utxoView().GetSnapshotValidatorByPKID(pkid)
+			snapshotValidatorSetEntry, err := utxoView().GetSnapshotValidatorSetEntryByPKID(pkid)
 			require.NoError(t, err)
-			require.Nil(t, snapshotValidatorEntry)
+			require.Nil(t, snapshotValidatorSetEntry)
 		}
 
 		// Test SnapshotTopActiveValidatorsByStake is empty.
@@ -297,9 +297,9 @@ func TestRunEpochCompleteHook(t *testing.T) {
 
 		// Test SnapshotValidatorByPKID is populated.
 		for _, pkid := range validatorPKIDs {
-			snapshotValidatorEntry, err := utxoView().GetSnapshotValidatorByPKID(pkid)
+			snapshotValidatorSetEntry, err := utxoView().GetSnapshotValidatorSetEntryByPKID(pkid)
 			require.NoError(t, err)
-			require.NotNil(t, snapshotValidatorEntry)
+			require.NotNil(t, snapshotValidatorSetEntry)
 		}
 
 		// Test SnapshotTopActiveValidatorsByStake is populated.
@@ -345,7 +345,7 @@ func TestRunEpochCompleteHook(t *testing.T) {
 		_runOnEpochCompleteHook()
 
 		// Snapshot m5 still has 600 staked.
-		validatorEntry, err = utxoView().GetSnapshotValidatorByPKID(m5PKID)
+		validatorEntry, err = utxoView().GetSnapshotValidatorSetEntryByPKID(m5PKID)
 		require.NoError(t, err)
 		require.NotNil(t, validatorEntry)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos.Uint64(), uint64(600))
@@ -354,7 +354,7 @@ func TestRunEpochCompleteHook(t *testing.T) {
 		_runOnEpochCompleteHook()
 
 		// Snapshot m5 now has 800 staked.
-		validatorEntry, err = utxoView().GetSnapshotValidatorByPKID(m5PKID)
+		validatorEntry, err = utxoView().GetSnapshotValidatorSetEntryByPKID(m5PKID)
 		require.NoError(t, err)
 		require.NotNil(t, validatorEntry)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos.Uint64(), uint64(800))
@@ -397,9 +397,9 @@ func TestRunEpochCompleteHook(t *testing.T) {
 		// Test snapshotting changing validator set.
 
 		// m0 unregisters as a validator.
-		snapshotValidatorEntries, err := utxoView().GetSnapshotValidatorSetByStake(10)
+		snapshotValidatorSet, err := utxoView().GetSnapshotValidatorSetByStake(10)
 		require.NoError(t, err)
-		require.Len(t, snapshotValidatorEntries, 7)
+		require.Len(t, snapshotValidatorSet, 7)
 
 		_, err = _submitUnregisterAsValidatorTxn(testMeta, m0Pub, m0Priv, true)
 		require.NoError(t, err)
@@ -408,17 +408,17 @@ func TestRunEpochCompleteHook(t *testing.T) {
 		_runOnEpochCompleteHook()
 
 		// m0 is still in the snapshot validator set.
-		snapshotValidatorEntries, err = utxoView().GetSnapshotValidatorSetByStake(10)
+		snapshotValidatorSet, err = utxoView().GetSnapshotValidatorSetByStake(10)
 		require.NoError(t, err)
-		require.Len(t, snapshotValidatorEntries, 7)
+		require.Len(t, snapshotValidatorSet, 7)
 
 		// Run OnEpochCompleteHook().
 		_runOnEpochCompleteHook()
 
 		// m0 is dropped from the snapshot validator set.
-		snapshotValidatorEntries, err = utxoView().GetSnapshotValidatorSetByStake(10)
+		snapshotValidatorSet, err = utxoView().GetSnapshotValidatorSetByStake(10)
 		require.NoError(t, err)
-		require.Len(t, snapshotValidatorEntries, 6)
+		require.Len(t, snapshotValidatorSet, 6)
 	}
 	{
 		// Test jailing inactive validators.
@@ -446,9 +446,9 @@ func TestRunEpochCompleteHook(t *testing.T) {
 		}
 
 		getNumSnapshotActiveValidators := func() int {
-			snapshotValidatorEntries, err := utxoView().GetSnapshotValidatorSetByStake(10)
+			snapshotValidatorSet, err := utxoView().GetSnapshotValidatorSetByStake(10)
 			require.NoError(t, err)
-			return len(snapshotValidatorEntries)
+			return len(snapshotValidatorSet)
 		}
 
 		getCurrentValidator := func(validatorPKID *PKID) *ValidatorEntry {


### PR DESCRIPTION
The SnapshotValidatorEntry indices were originally created to snapshot every registered validators. Moving forward, the indices only contain the top n active validator set for an epoch. Renaming to SnapshotValidatorSet is more appropriate.