### PR TITLE
PoS Deprecate GlobalActiveStakeAmountNanos

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -118,9 +118,6 @@ type UtxoView struct {
 	// Validator mappings
 	ValidatorPKIDToValidatorEntry map[PKID]*ValidatorEntry
 
-	// The global active stake is the sum of all stake across validators who have Status = Active.
-	GlobalActiveStakeAmountNanos *uint256.Int
-
 	// Stake mappings
 	StakeMapKeyToStakeEntry map[StakeMapKey]*StakeEntry
 
@@ -242,11 +239,6 @@ func (bav *UtxoView) _ResetViewMappingsAfterFlush() {
 
 	// ValidatorEntries
 	bav.ValidatorPKIDToValidatorEntry = make(map[PKID]*ValidatorEntry)
-
-	// Global active stake across validators. We deliberately want this to initialize to nil and not zero
-	// since a zero value will overwrite an existing GlobalActiveStakeAmountNanos value in the db, whereas
-	// a nil GlobalActiveStakeAmountNanos value signifies that this value was never set.
-	bav.GlobalActiveStakeAmountNanos = nil
 
 	// StakeEntries
 	bav.StakeMapKeyToStakeEntry = make(map[StakeMapKey]*StakeEntry)
@@ -524,11 +516,6 @@ func (bav *UtxoView) CopyUtxoView() (*UtxoView, error) {
 	newView.ValidatorPKIDToValidatorEntry = make(map[PKID]*ValidatorEntry, len(bav.ValidatorPKIDToValidatorEntry))
 	for entryKey, entry := range bav.ValidatorPKIDToValidatorEntry {
 		newView.ValidatorPKIDToValidatorEntry[entryKey] = entry.Copy()
-	}
-
-	// Copy the GlobalActiveStakeAmountNanos.
-	if bav.GlobalActiveStakeAmountNanos != nil {
-		newView.GlobalActiveStakeAmountNanos = bav.GlobalActiveStakeAmountNanos.Clone()
 	}
 
 	// Copy the StakeEntries

--- a/lib/block_view_flush.go
+++ b/lib/block_view_flush.go
@@ -144,9 +144,6 @@ func (bav *UtxoView) FlushToDbWithTxn(txn *badger.Txn, blockHeight uint64) error
 	if err := bav._flushValidatorEntriesToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}
-	if err := bav._flushGlobalActiveStakeAmountNanosToDbWithTxn(txn, blockHeight); err != nil {
-		return err
-	}
 	if err := bav._flushStakeEntriesToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}

--- a/lib/block_view_stake_test.go
+++ b/lib/block_view_stake_test.go
@@ -223,11 +223,6 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		require.NotNil(t, validatorEntry)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
 
-		// Verify GlobalActiveStakeAmountNanos.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(100))
-
 		// Verify m1's DESO balance decreases by StakeAmountNanos (net of fees).
 		m1NewDESOBalanceNanos := getDESOBalanceNanos(m1PkBytes)
 		require.Equal(t, m1OldDESOBalanceNanos-feeNanos-stakeMetadata.StakeAmountNanos.Uint64(), m1NewDESOBalanceNanos)
@@ -257,11 +252,6 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		require.NoError(t, err)
 		require.NotNil(t, validatorEntry)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(150))
-
-		// Verify GlobalActiveStakeAmountNanos.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(150))
 
 		// Verify m1's DESO balance decreases by StakeAmountNanos (net of fees).
 		m1NewDESOBalanceNanos := getDESOBalanceNanos(m1PkBytes)
@@ -373,11 +363,6 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(110))
 
-		// Verify GlobalActiveStakeAmountNanos.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(110))
-
 		// Verify LockedStakeEntry.UnstakeAmountNanos.
 		lockedStakeEntry, err := utxoView().GetLockedStakeEntry(m0PKID, m1PKID, currentEpochNumber)
 		require.NoError(t, err)
@@ -411,11 +396,6 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(80))
 
-		// Verify GlobalActiveStakeAmountNanos.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(80))
-
 		// Verify LockedStakeEntry.UnstakeAmountNanos.
 		lockedStakeEntry, err := utxoView().GetLockedStakeEntry(m0PKID, m1PKID, currentEpochNumber)
 		require.NoError(t, err)
@@ -447,11 +427,6 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt())
-
-		// Verify GlobalActiveStakeAmountNanos.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 
 		// Verify LockedStakeEntry.UnstakeAmountNanos.
 		lockedStakeEntry, err := utxoView().GetLockedStakeEntry(m0PKID, m1PKID, currentEpochNumber)
@@ -555,11 +530,6 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt())
-
-		// Verify GlobalActiveStakeAmountNanos.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 
 		// Verify LockedStakeEntry.isDeleted.
 		lockedStakeEntry, err := utxoView().GetLockedStakeEntry(m0PKID, m1PKID, currentEpochNumber)
@@ -1980,14 +1950,9 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(validatorPKID)
 		require.NoError(t, err)
 
-		// Retrieve current GlobalActiveStakeAmountNanos.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-
 		// Jail the validator.
 		tmpUtxoView, err := NewUtxoView(db, params, chain.postgres, chain.snapshot)
 		require.NoError(t, err)
-		tmpUtxoView._setGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos)
 		require.NoError(t, tmpUtxoView.JailValidator(validatorEntry))
 		require.NoError(t, tmpUtxoView.FlushToDb(blockHeight))
 
@@ -1995,9 +1960,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		// from the UtxoView so that they are next read from the db.
 		delete(mempool.universalUtxoView.ValidatorPKIDToValidatorEntry, *validatorPKID)
 		delete(mempool.readOnlyUtxoView.ValidatorPKIDToValidatorEntry, *validatorPKID)
-		mempool.universalUtxoView.GlobalActiveStakeAmountNanos = nil
-		mempool.readOnlyUtxoView.GlobalActiveStakeAmountNanos = nil
-
 	}
 
 	// Seed a CurrentEpochEntry.
@@ -2040,11 +2002,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(150))
-
-		// GlobalActiveStakeAmountNanos increases.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(150))
 	}
 	{
 		// m1 unstakes some from m0. m0 is active.
@@ -2059,11 +2016,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
-
-		// GlobalActiveStakeAmountNanos decreases.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(100))
 	}
 	{
 		// Jail m0. Since this update takes place outside a transaction,
@@ -2079,11 +2031,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 
 		// m0 TotalStakeAmountNanos stays the same.
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
-
-		// GlobalActiveStakeAmountNanos decreases.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 	}
 	{
 		// m1 stakes more with m0. m0 is jailed.
@@ -2098,11 +2045,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(150))
-
-		// GlobalActiveStakeAmountNanos stays the same.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 	}
 	{
 		// m1 unstakes some from m0. m0 is jailed.
@@ -2117,11 +2059,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
-
-		// GlobalActiveStakeAmountNanos stays the same.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 	}
 	{
 		// m0 unjails himself.
@@ -2132,11 +2069,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
-
-		// GlobalActiveStakeAmountNanos increases.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(100))
 	}
 	{
 		// m1 stakes more with m0. m0 is active.
@@ -2151,11 +2083,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(150))
-
-		// GlobalActiveStakeAmountNanos increases.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(150))
 	}
 	{
 		// m1 unstakes some from m0. m0 is active.
@@ -2170,11 +2097,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
-
-		// GlobalActiveStakeAmountNanos decreases.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(100))
 	}
 	{
 		// Jail m0 again. Since this update takes place outside a transaction,
@@ -2186,11 +2108,6 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
-
-		// GlobalActiveStakeAmountNanos decreases.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 	}
 	{
 		// m0 unregisters as a validator.
@@ -2201,10 +2118,5 @@ func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.Nil(t, validatorEntry)
-
-		// GlobalActiveStakeAmountNanos stays the same.
-		globalActiveStakeAmountNanos, err := utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 	}
 }

--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -913,10 +913,6 @@ type UtxoOperation struct {
 	// register, unregister, stake, or unstake txn.
 	PrevValidatorEntry *ValidatorEntry
 
-	// PrevGlobalActiveStakeAmountNanos is the previous GlobalActiveStakeAmountNanos
-	// prior to a stake or unstake operation txn.
-	PrevGlobalActiveStakeAmountNanos *uint256.Int
-
 	// PrevStakeEntries is a slice of StakeEntries prior to
 	// a register, unregister, stake, or unstake txn.
 	PrevStakeEntries []*StakeEntry
@@ -1244,9 +1240,6 @@ func (op *UtxoOperation) RawEncodeWithoutMetadata(blockHeight uint64, skipMetada
 	if MigrationTriggered(blockHeight, ProofOfStake1StateSetupMigration) {
 		// PrevValidatorEntry
 		data = append(data, EncodeToBytes(blockHeight, op.PrevValidatorEntry, skipMetadata...)...)
-
-		// PrevGlobalActiveStakeAmountNanos
-		data = append(data, VariableEncodeUint256(op.PrevGlobalActiveStakeAmountNanos)...)
 
 		// PrevStakeEntries
 		data = append(data, EncodeDeSoEncoderSlice(op.PrevStakeEntries, blockHeight, skipMetadata...)...)
@@ -1874,11 +1867,6 @@ func (op *UtxoOperation) RawDecodeWithoutMetadata(blockHeight uint64, rr *bytes.
 		// PrevValidatorEntry
 		if op.PrevValidatorEntry, err = DecodeDeSoEncoder(&ValidatorEntry{}, rr); err != nil {
 			return errors.Wrapf(err, "UtxoOperation.Decode: Problem reading PrevValidatorEntry: ")
-		}
-
-		// PrevGlobalActiveStakeAmountNanos
-		if op.PrevGlobalActiveStakeAmountNanos, err = VariableDecodeUint256(rr); err != nil {
-			return errors.Wrapf(err, "UtxoOperation.Decode: Problem reading PrevGlobalActiveStakeAmountNanos: ")
 		}
 
 		// PrevStakeEntries

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1316,35 +1316,12 @@ func (bav *UtxoView) _connectUnregisterAsValidator(
 		)
 	}
 
-	// If the validator was active, decrease the GlobalActiveStakeAmountNanos
-	// by the amount that was unstaked. Do nothing if the validator was jailed.
-	var prevGlobalActiveStakeAmountNanos *uint256.Int
-	if prevValidatorEntry.Status() == ValidatorStatusActive {
-		// Fetch the existing GlobalActiveStakeAmountNanos.
-		prevGlobalActiveStakeAmountNanos, err = bav.GetGlobalActiveStakeAmountNanos()
-		if err != nil {
-			return 0, 0, nil, errors.Wrapf(err, "_connectUnregisterAsValidator: error fetching GlobalActiveStakeAmountNanos: ")
-		}
-		// Subtract the amount that was unstaked.
-		globalActiveStakeAmountNanos, err := SafeUint256().Sub(
-			prevGlobalActiveStakeAmountNanos, totalUnstakedAmountNanos,
-		)
-		if err != nil {
-			return 0, 0, nil, errors.Wrapf(
-				err, "_connectUnregisterAsValidator: error subtracting TotalUnstakedAmountNanos from GlobalActiveStakeAmountNanos: ",
-			)
-		}
-		// Set the new GlobalActiveStakeAmountNanos.
-		bav._setGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos)
-	}
-
 	// Create a UTXO operation.
 	utxoOpForTxn := &UtxoOperation{
-		Type:                             OperationTypeUnregisterAsValidator,
-		PrevValidatorEntry:               prevValidatorEntry,
-		PrevGlobalActiveStakeAmountNanos: prevGlobalActiveStakeAmountNanos,
-		PrevStakeEntries:                 prevStakeEntries,
-		PrevLockedStakeEntries:           prevLockedStakeEntries,
+		Type:                   OperationTypeUnregisterAsValidator,
+		PrevValidatorEntry:     prevValidatorEntry,
+		PrevStakeEntries:       prevStakeEntries,
+		PrevLockedStakeEntries: prevLockedStakeEntries,
 	}
 	if err = bav.SanityCheckUnregisterAsValidatorTxn(transactorPKIDEntry.PKID, utxoOpForTxn, totalUnstakedAmountNanos); err != nil {
 		return 0, 0, nil, errors.Wrapf(err, "_connectUnregisterAsValidator: ")
@@ -1422,11 +1399,6 @@ func (bav *UtxoView) _disconnectUnregisterAsValidator(
 
 		// Set the PrevLockedStakeEntry.
 		bav._setLockedStakeEntryMappings(prevLockedStakeEntry)
-	}
-
-	// Restore the PrevGlobalActiveStakeAmountNanos, if exists.
-	if operationData.PrevGlobalActiveStakeAmountNanos != nil {
-		bav._setGlobalActiveStakeAmountNanos(operationData.PrevGlobalActiveStakeAmountNanos)
 	}
 
 	// Disconnect the BasicTransfer.
@@ -1522,24 +1494,10 @@ func (bav *UtxoView) _connectUnjailValidator(
 	// Set the CurrentValidatorEntry.
 	bav._setValidatorEntryMappings(currentValidatorEntry)
 
-	// Increase the GlobalActiveStakeAmountNanos.
-	prevGlobalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
-	if err != nil {
-		return 0, 0, nil, errors.Wrapf(err, "_connectUnjailValidator: error retrieving existing GlobalActiveStakeAmountNanos: ")
-	}
-	currentGlobalActiveStakeAmountNanos, err := SafeUint256().Add(
-		prevGlobalActiveStakeAmountNanos, currentValidatorEntry.TotalStakeAmountNanos,
-	)
-	if err != nil {
-		return 0, 0, nil, errors.Wrapf(err, "_connectUnjailValidator: error calculating updated GlobalActiveStakeAmountNanos ")
-	}
-	bav._setGlobalActiveStakeAmountNanos(currentGlobalActiveStakeAmountNanos)
-
 	// Add a UTXO operation
 	utxoOpsForTxn = append(utxoOpsForTxn, &UtxoOperation{
-		Type:                             OperationTypeUnjailValidator,
-		PrevValidatorEntry:               prevValidatorEntry,
-		PrevGlobalActiveStakeAmountNanos: prevGlobalActiveStakeAmountNanos,
+		Type:               OperationTypeUnjailValidator,
+		PrevValidatorEntry: prevValidatorEntry,
 	})
 	return totalInput, totalOutput, utxoOpsForTxn, nil
 }
@@ -1592,13 +1550,6 @@ func (bav *UtxoView) _disconnectUnjailValidator(
 		return errors.New("_disconnectUnjailValidator: PrevValidatorEntry is nil")
 	}
 	bav._setValidatorEntryMappings(prevValidatorEntry)
-
-	// Restore the PrevGlobalActiveStakeAmountNanos.
-	prevGlobalActiveStakeAmountNanos := operationData.PrevGlobalActiveStakeAmountNanos
-	if prevGlobalActiveStakeAmountNanos == nil {
-		return errors.New("_disconnectUnjailValidator: PrevGlobalActiveStakeAmountNanos is nil, this should never happen")
-	}
-	bav._setGlobalActiveStakeAmountNanos(prevGlobalActiveStakeAmountNanos)
 
 	// Disconnect the BasicTransfer.
 	return bav._disconnectBasicTransfer(
@@ -1792,27 +1743,6 @@ func (bav *UtxoView) SanityCheckUnregisterAsValidatorTxn(
 	}
 	if !totalUnstakedAmountNanos.Eq(amountNanos) {
 		return errors.New("SanityCheckUnregisterAsValidatorTxn: TotalUnstakedAmountNanos doesn't match")
-	}
-
-	// Sanity check that the GlobalActiveStakeAmountNanos was decreased
-	// by amountNanos if the PrevValidatorEntry was active.
-	if utxoOp.PrevValidatorEntry.Status() == ValidatorStatusActive {
-		if utxoOp.PrevGlobalActiveStakeAmountNanos == nil {
-			return errors.New("SanityCheckUnregisterAsValidatorTxn: nil PrevGlobalActiveStakeAmountNanos provided")
-		}
-		currentGlobalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
-		if err != nil {
-			return errors.Wrapf(err, "SanityCheckUnregisterAsValidatorTxn: error retrieving GlobalActiveStakeAmountNanos: ")
-		}
-		globalActiveStakeAmountNanosDecrease, err := SafeUint256().Sub(utxoOp.PrevGlobalActiveStakeAmountNanos, currentGlobalActiveStakeAmountNanos)
-		if err != nil {
-			return errors.Wrapf(err, "SanityCheckUnregisterAsValidatorTxn: error calculating GlobalActiveStakeAmountNanos decrease: ")
-		}
-		if !globalActiveStakeAmountNanosDecrease.Eq(amountNanos) {
-			return errors.New("SanityCheckUnregisterAsValidatorTxn: GlobalActiveStakeAmountNanos decrease doesn't match")
-		}
-	} else if utxoOp.PrevGlobalActiveStakeAmountNanos != nil {
-		return errors.New("SanityCheckUnregisterAsValidatorTxn: non-nil PrevGlobalActiveStakeAmountNanos provided for inactive validator")
 	}
 
 	return nil
@@ -2066,23 +1996,8 @@ func (bav *UtxoView) JailValidator(validatorEntry *ValidatorEntry) error {
 	// Set ValidatorEntry.JailedAtEpochNumber to the CurrentEpochNumber.
 	validatorEntry.JailedAtEpochNumber = currentEpochNumber
 
-	// Remove the validator's stake from the GlobalActiveStakeAmountNanos.
-	prevGlobalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
-	if err != nil {
-		return errors.Wrapf(err, "UtxoView.JailValidator: error retrieving GlobalActiveStakeAmountNanos: ")
-	}
-	currentGlobalActiveStakeAmountNanos, err := SafeUint256().Sub(
-		prevGlobalActiveStakeAmountNanos, validatorEntry.TotalStakeAmountNanos,
-	)
-	if err != nil {
-		return errors.Wrapf(err, "UtxoView.JailValidator: error calculating updated GlobalActiveStakeAmountNanos: ")
-	}
-
 	// Store the updated ValidatorEntry.
 	bav._setValidatorEntryMappings(validatorEntry)
-
-	// Store the updated GlobalActiveStakeAmountNanos.
-	bav._setGlobalActiveStakeAmountNanos(currentGlobalActiveStakeAmountNanos)
 
 	return nil
 }
@@ -2149,16 +2064,6 @@ func (bav *UtxoView) _flushValidatorEntriesToDbWithTxn(txn *badger.Txn, blockHei
 	}
 
 	return nil
-}
-
-func (bav *UtxoView) _flushGlobalActiveStakeAmountNanosToDbWithTxn(txn *badger.Txn, blockHeight uint64) error {
-	// If GlobalActiveStakeAmountNanos is nil, then it was never
-	// set and shouldn't overwrite the value in the db.
-	if bav.GlobalActiveStakeAmountNanos == nil {
-		return nil
-	}
-
-	return DBPutGlobalActiveStakeAmountNanosWithTxn(txn, bav.Snapshot, bav.GlobalActiveStakeAmountNanos, blockHeight)
 }
 
 //
@@ -2268,6 +2173,14 @@ func (bav *UtxoView) CreateUnjailValidatorTxindexMetadata(
 	}
 
 	return &UnjailValidatorTxindexMetadata{}, affectedPublicKeys
+}
+
+func SumValidatorStakeAmountNanos(validatorEntries []*ValidatorEntry) *uint256.Int {
+	totalStakeAmountNanos := uint256.NewInt()
+	for _, validatorEntry := range validatorEntries {
+		totalStakeAmountNanos.Add(totalStakeAmountNanos, validatorEntry.TotalStakeAmountNanos)
+	}
+	return totalStakeAmountNanos
 }
 
 //

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -2124,7 +2124,7 @@ func (bav *UtxoView) CreateUnjailValidatorTxindexMetadata(
 	return &UnjailValidatorTxindexMetadata{}, affectedPublicKeys
 }
 
-func SumValidatorStakeAmountNanos(validatorEntries []*ValidatorEntry) *uint256.Int {
+func SumValidatorEntriesTotalStakeAmountNanos(validatorEntries []*ValidatorEntry) *uint256.Int {
 	totalStakeAmountNanos := uint256.NewInt()
 	for _, validatorEntry := range validatorEntries {
 		totalStakeAmountNanos.Add(totalStakeAmountNanos, validatorEntry.TotalStakeAmountNanos)

--- a/lib/block_view_validator_test.go
+++ b/lib/block_view_validator_test.go
@@ -24,7 +24,6 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 	var registerMetadata *RegisterAsValidatorMetadata
 	var validatorEntry *ValidatorEntry
 	var validatorEntries []*ValidatorEntry
-	var globalActiveStakeAmountNanos *uint256.Int
 	var err error
 
 	// Initialize balance model fork heights.
@@ -229,12 +228,6 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 		require.Empty(t, validatorEntries)
 	}
 	{
-		// Query: retrieve GlobalActiveStakeAmountNanos
-		globalActiveStakeAmountNanos, err = utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
-	}
-	{
 		// Happy path: update a validator
 		votingPublicKey, votingAuthorization := _generateVotingPublicKeyAndAuthorization(t, m0PkBytes)
 		registerMetadata = &RegisterAsValidatorMetadata{
@@ -286,12 +279,6 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 		validatorEntries, err = utxoView().GetTopActiveValidatorsByStake(1)
 		require.NoError(t, err)
 		require.Empty(t, validatorEntries)
-	}
-	{
-		// Query: retrieve GlobalActiveStakeAmountNanos
-		globalActiveStakeAmountNanos, err = utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 	}
 
 	// Flush mempool to the db and test rollbacks.
@@ -1300,7 +1287,6 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 	var stakeEntry *StakeEntry
 	var lockedStakeEntry *LockedStakeEntry
 	_ = lockedStakeEntry
-	var globalActiveStakeAmountNanos *uint256.Int
 	var err error
 
 	// Initialize balance model fork heights.
@@ -1392,10 +1378,6 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 		require.NoError(t, err)
 		require.NotNil(t, stakeEntry)
 		require.Equal(t, stakeEntry.StakeAmountNanos, uint256.NewInt().SetUint64(600))
-
-		globalActiveStakeAmountNanos, err = utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(600))
 	}
 	{
 		// m1 stakes with m0.
@@ -1412,10 +1394,6 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 		require.NoError(t, err)
 		require.NotNil(t, stakeEntry)
 		require.Equal(t, stakeEntry.StakeAmountNanos, uint256.NewInt().SetUint64(400))
-
-		globalActiveStakeAmountNanos, err = utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(1000))
 	}
 	{
 		// m1 partially unstakes with m0.
@@ -1438,11 +1416,6 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 		require.NoError(t, err)
 		require.NotNil(t, lockedStakeEntry)
 		require.Equal(t, lockedStakeEntry.LockedAmountNanos, uint256.NewInt().SetUint64(100))
-
-		// GlobalActiveStakeAmountNanos is updated.
-		globalActiveStakeAmountNanos, err = utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt().SetUint64(900))
 	}
 	{
 		// m0 unregisters as a validator.
@@ -1475,11 +1448,6 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 		require.NoError(t, err)
 		require.NotNil(t, lockedStakeEntry)
 		require.Equal(t, lockedStakeEntry.LockedAmountNanos, uint256.NewInt().SetUint64(400))
-
-		// GlobalActiveStakeAmountNanos is updated.
-		globalActiveStakeAmountNanos, err = utxoView().GetGlobalActiveStakeAmountNanos()
-		require.NoError(t, err)
-		require.Equal(t, globalActiveStakeAmountNanos, uint256.NewInt())
 	}
 
 	// Flush mempool to the db and test rollbacks.

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -486,13 +486,9 @@ type DBPrefixes struct {
 	// Note that we save space by storing a nil value and parsing the ValidatorPKID from the key.
 	PrefixValidatorByStatusAndStake []byte `prefix_id:"[79]" is_state:"true"`
 
-	// PrefixGlobalActiveStakeAmountNanos: Retrieve the cumulative stake across all validators.
-	// Prefix -> *uint256.Int
-	PrefixGlobalActiveStakeAmountNanos []byte `prefix_id:"[80]" is_state:"true"`
-
 	// PrefixStakeByValidatorAndStaker: Retrieve a StakeEntry.
 	// Prefix, <ValidatorPKID [33]byte>, <StakerPKID [33]byte> -> StakeEntry
-	PrefixStakeByValidatorAndStaker []byte `prefix_id:"[81]" is_state:"true"`
+	PrefixStakeByValidatorAndStaker []byte `prefix_id:"[80]" is_state:"true"`
 
 	// PrefixLockedStakeByValidatorAndStakerAndLockedAt: Retrieve a LockedStakeEntry.
 	// Prefix, <ValidatorPKID [33]byte>, <StakerPKID [33]byte>, <LockedAtEpochNumber uint64> -> LockedStakeEntry
@@ -519,40 +515,40 @@ type DBPrefixes struct {
 	//   (CurrentEpoch - LockedAtEpochNumber) = 133 - 123 = 10, which is greater than
 	//   cooldown=3. Thus the UnlockStake will succeed, which will result in the
 	//   LockedStakeEntry being deleted and 25 DESO being added to the user's balance.
-	PrefixLockedStakeByValidatorAndStakerAndLockedAt []byte `prefix_id:"[82]" is_state:"true"`
+	PrefixLockedStakeByValidatorAndStakerAndLockedAt []byte `prefix_id:"[81]" is_state:"true"`
 
 	// PrefixCurrentEpoch: Retrieve the current EpochEntry.
 	// Prefix -> EpochEntry
-	PrefixCurrentEpoch []byte `prefix_id:"[83]" is_state:"true"`
+	PrefixCurrentEpoch []byte `prefix_id:"[82]" is_state:"true"`
 
 	// PrefixCurrentRandomSeedHash: Retrieve the current RandomSeedHash.
 	// Prefix -> <RandomSeedHash [32]byte>.
-	PrefixCurrentRandomSeedHash []byte `prefix_id:"[84]" is_state:"true"`
+	PrefixCurrentRandomSeedHash []byte `prefix_id:"[83]" is_state:"true"`
 
 	// PrefixSnapshotGlobalParamsEntry: Retrieve a snapshot GlobalParamsEntry by SnapshotAtEpochNumber.
 	// Prefix, <SnapshotAtEpochNumber uint64> -> *GlobalParamsEntry
-	PrefixSnapshotGlobalParamsEntry []byte `prefix_id:"[85]" is_state:"true"`
+	PrefixSnapshotGlobalParamsEntry []byte `prefix_id:"[84]" is_state:"true"`
 
 	// PrefixSnapshotValidatorSetByPKID: Retrieve a ValidatorEntry from a snapshot validator set by
 	// <SnapshotAtEpochNumber, PKID>.
 	// Prefix, <SnapshotAtEpochNumber uint64>, <ValidatorPKID [33]byte> -> *ValidatorEntry
-	PrefixSnapshotValidatorSetByPKID []byte `prefix_id:"[86]" is_state:"true"`
+	PrefixSnapshotValidatorSetByPKID []byte `prefix_id:"[85]" is_state:"true"`
 
 	// PrefixSnapshotValidatorSetByStake: Retrieve stake-ordered ValidatorEntries from a snapshot validator set
 	// by SnapshotAtEpochNumber.
 	// Prefix, <SnapshotAtEpochNumber uint64>, <TotalStakeAmountNanos *uint256.Int>, <ValidatorPKID [33]byte> -> nil
 	// Note: we parse the ValidatorPKID from the key and the value is nil to save space.
-	PrefixSnapshotValidatorSetByStake []byte `prefix_id:"[87]" is_state:"true"`
+	PrefixSnapshotValidatorSetByStake []byte `prefix_id:"[86]" is_state:"true"`
 
 	// PrefixSnapshotGlobalActiveStakeAmountNanos: Retrieve a snapshot GlobalActiveStakeAmountNanos by SnapshotAtEpochNumber.
 	// Prefix, <SnapshotAtEpochNumber uint64> -> *uint256.Int
-	PrefixSnapshotGlobalActiveStakeAmountNanos []byte `prefix_id:"[88]" is_state:"true"`
+	PrefixSnapshotGlobalActiveStakeAmountNanos []byte `prefix_id:"[87]" is_state:"true"`
 
 	// PrefixSnapshotLeaderSchedule: Retrieve a ValidatorPKID by <SnapshotAtEpochNumber, LeaderIndex>.
 	// Prefix, <SnapshotAtEpochNumber uint64>, <LeaderIndex uint16> -> ValidatorPKID
-	PrefixSnapshotLeaderSchedule []byte `prefix_id:"[89]" is_state:"true"`
+	PrefixSnapshotLeaderSchedule []byte `prefix_id:"[88]" is_state:"true"`
 
-	// NEXT_TAG: 90
+	// NEXT_TAG: 89
 }
 
 // StatePrefixToDeSoEncoder maps each state prefix to a DeSoEncoder type that is stored under that prefix.
@@ -760,35 +756,32 @@ func StatePrefixToDeSoEncoder(prefix []byte) (_isEncoder bool, _encoder DeSoEnco
 	} else if bytes.Equal(prefix, Prefixes.PrefixValidatorByStatusAndStake) {
 		// prefix_id:"[79]"
 		return false, nil
-	} else if bytes.Equal(prefix, Prefixes.PrefixGlobalActiveStakeAmountNanos) {
-		// prefix_id:"[80]"
-		return false, nil
 	} else if bytes.Equal(prefix, Prefixes.PrefixStakeByValidatorAndStaker) {
-		// prefix_id:"[81]"
+		// prefix_id:"[80]"
 		return true, &StakeEntry{}
 	} else if bytes.Equal(prefix, Prefixes.PrefixLockedStakeByValidatorAndStakerAndLockedAt) {
-		// prefix_id:"[82]"
+		// prefix_id:"[81]"
 		return true, &LockedStakeEntry{}
 	} else if bytes.Equal(prefix, Prefixes.PrefixCurrentEpoch) {
-		// prefix_id:"[83]"
+		// prefix_id:"[82]"
 		return true, &EpochEntry{}
 	} else if bytes.Equal(prefix, Prefixes.PrefixCurrentRandomSeedHash) {
-		// prefix_id:"[84]"
+		// prefix_id:"[83]"
 		return false, nil
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotGlobalParamsEntry) {
-		// prefix_id:"[85]"
+		// prefix_id:"[84]"
 		return true, &GlobalParamsEntry{}
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorSetByPKID) {
-		// prefix_id:"[86]"
+		// prefix_id:"[85]"
 		return true, &ValidatorEntry{}
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorSetByStake) {
-		// prefix_id:"[87]"
+		// prefix_id:"[86]"
 		return false, nil
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotGlobalActiveStakeAmountNanos) {
-		// prefix_id:"[88]"
+		// prefix_id:"[87]"
 		return false, nil
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotLeaderSchedule) {
-		// prefix_id:"[89]"
+		// prefix_id:"[88]"
 		return true, &PKID{}
 	}
 

--- a/lib/pos_epoch_complete_hook.go
+++ b/lib/pos_epoch_complete_hook.go
@@ -83,11 +83,8 @@ func (bav *UtxoView) RunEpochCompleteHook(blockHeight uint64) error {
 		bav._setSnapshotValidatorSetEntry(validatorEntry, currentEpochEntry.EpochNumber)
 	}
 
-	// Snapshot the current GlobalActiveStakeAmountNanos.
-	globalActiveStakeAmountNanos, err := bav.GetGlobalActiveStakeAmountNanos()
-	if err != nil {
-		return errors.Wrapf(err, "RunEpochCompleteHook: problem retrieving GlobalActiveStakeAmountNanos: ")
-	}
+	// Snapshot the current validator set's total stake.
+	globalActiveStakeAmountNanos := SumValidatorStakeAmountNanos(validatorSet)
 	bav._setSnapshotGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos, currentEpochEntry.EpochNumber)
 
 	// Generate + snapshot a leader schedule.

--- a/lib/pos_epoch_complete_hook.go
+++ b/lib/pos_epoch_complete_hook.go
@@ -83,7 +83,8 @@ func (bav *UtxoView) RunEpochCompleteHook(blockHeight uint64) error {
 		bav._setSnapshotValidatorSetEntry(validatorEntry, currentEpochEntry.EpochNumber)
 	}
 
-	// Snapshot the current validator set's total stake.
+	// Snapshot the current validator set's total stake. Note, the validator set is already filtered to the top n
+	// active validators for the epoch. The total stake is the sum of all of the active validators' stakes.
 	globalActiveStakeAmountNanos := SumValidatorEntriesTotalStakeAmountNanos(validatorSet)
 	bav._setSnapshotGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos, currentEpochEntry.EpochNumber)
 

--- a/lib/pos_epoch_complete_hook.go
+++ b/lib/pos_epoch_complete_hook.go
@@ -84,7 +84,7 @@ func (bav *UtxoView) RunEpochCompleteHook(blockHeight uint64) error {
 	}
 
 	// Snapshot the current validator set's total stake.
-	globalActiveStakeAmountNanos := SumValidatorStakeAmountNanos(validatorSet)
+	globalActiveStakeAmountNanos := SumValidatorEntriesTotalStakeAmountNanos(validatorSet)
 	bav._setSnapshotGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos, currentEpochEntry.EpochNumber)
 
 	// Generate + snapshot a leader schedule.


### PR DESCRIPTION
The index previously tracked the global amount of DESO staked. This is no longer necessary as the validator set is limited in size, and will change on each epoch transition. The total stake for the validator set needs to be recomputed on epoch transitions.