### PR TITLE
PoS Rename SnapshotGlobalActiveStakeAmountNanos to SnapshotValidatorSetTotalStakeAmountNanos

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -139,9 +139,9 @@ type UtxoView struct {
 	// the given SnapshotAtEpochNumber.
 	SnapshotValidatorSet map[SnapshotValidatorSetMapKey]*ValidatorEntry
 
-	// SnapshotGlobalActiveStakeAmountNanos is a map of SnapshotAtEpochNumber to a GlobalActiveStakeAmountNanos.
+	// SnapshotValidatorSetTotalStakeAmountNanos is a map of SnapshotAtEpochNumber to a GlobalActiveStakeAmountNanos.
 	// It contains the snapshot value of the GlobalActiveStakeAmountNanos at the given SnapshotAtEpochNumber.
-	SnapshotGlobalActiveStakeAmountNanos map[uint64]*uint256.Int
+	SnapshotValidatorSetTotalStakeAmountNanos map[uint64]*uint256.Int
 
 	// SnapshotLeaderSchedule is a map of <SnapshotAtEpochNumber, LeaderIndex> to a ValidatorPKID.
 	// It contains the PKID of the validator at the given index in the leader schedule
@@ -255,8 +255,8 @@ func (bav *UtxoView) _ResetViewMappingsAfterFlush() {
 	// SnapshotValidatorSet
 	bav.SnapshotValidatorSet = make(map[SnapshotValidatorSetMapKey]*ValidatorEntry)
 
-	// SnapshotGlobalActiveStakeAmountNanos
-	bav.SnapshotGlobalActiveStakeAmountNanos = make(map[uint64]*uint256.Int)
+	// SnapshotValidatorSetTotalStakeAmountNanos
+	bav.SnapshotValidatorSetTotalStakeAmountNanos = make(map[uint64]*uint256.Int)
 
 	// SnapshotLeaderSchedule
 	bav.SnapshotLeaderSchedule = make(map[SnapshotLeaderScheduleMapKey]*PKID)
@@ -552,9 +552,9 @@ func (bav *UtxoView) CopyUtxoView() (*UtxoView, error) {
 		newView.SnapshotValidatorSet[mapKey] = validatorEntry.Copy()
 	}
 
-	// Copy the SnapshotGlobalActiveStakeAmountNanos
-	for epochNumber, globalActiveStakeAmountNanos := range bav.SnapshotGlobalActiveStakeAmountNanos {
-		newView.SnapshotGlobalActiveStakeAmountNanos[epochNumber] = globalActiveStakeAmountNanos.Clone()
+	// Copy the SnapshotValidatorSetTotalStakeAmountNanos
+	for epochNumber, globalActiveStakeAmountNanos := range bav.SnapshotValidatorSetTotalStakeAmountNanos {
+		newView.SnapshotValidatorSetTotalStakeAmountNanos[epochNumber] = globalActiveStakeAmountNanos.Clone()
 	}
 
 	// Copy the SnapshotLeaderSchedule

--- a/lib/block_view_flush.go
+++ b/lib/block_view_flush.go
@@ -165,7 +165,7 @@ func (bav *UtxoView) FlushToDbWithTxn(txn *badger.Txn, blockHeight uint64) error
 	if err := bav._flushSnapshotValidatorSetToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}
-	if err := bav._flushSnapshotGlobalActiveStakeAmountNanosToDbWithTxn(txn, blockHeight); err != nil {
+	if err := bav._flushSnapshotValidatorSetTotalStakeAmountNanosToDbWithTxn(txn, blockHeight); err != nil {
 		return err
 	}
 	if err := bav._flushSnapshotLeaderScheduleToDbWithTxn(txn, blockHeight); err != nil {

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -540,9 +540,10 @@ type DBPrefixes struct {
 	// Note: we parse the ValidatorPKID from the key and the value is nil to save space.
 	PrefixSnapshotValidatorSetByStake []byte `prefix_id:"[86]" is_state:"true"`
 
-	// PrefixSnapshotGlobalActiveStakeAmountNanos: Retrieve a snapshot GlobalActiveStakeAmountNanos by SnapshotAtEpochNumber.
+	// PrefixSnapshotValidatorSetTotalStakeAmountNanos: Retrieve a snapshot of the validator set's total amount of
+	// staked DESO by SnapshotAtEpochNumber.
 	// Prefix, <SnapshotAtEpochNumber uint64> -> *uint256.Int
-	PrefixSnapshotGlobalActiveStakeAmountNanos []byte `prefix_id:"[87]" is_state:"true"`
+	PrefixSnapshotValidatorSetTotalStakeAmountNanos []byte `prefix_id:"[87]" is_state:"true"`
 
 	// PrefixSnapshotLeaderSchedule: Retrieve a ValidatorPKID by <SnapshotAtEpochNumber, LeaderIndex>.
 	// Prefix, <SnapshotAtEpochNumber uint64>, <LeaderIndex uint16> -> ValidatorPKID
@@ -777,7 +778,7 @@ func StatePrefixToDeSoEncoder(prefix []byte) (_isEncoder bool, _encoder DeSoEnco
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorSetByStake) {
 		// prefix_id:"[86]"
 		return false, nil
-	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotGlobalActiveStakeAmountNanos) {
+	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotValidatorSetTotalStakeAmountNanos) {
 		// prefix_id:"[87]"
 		return false, nil
 	} else if bytes.Equal(prefix, Prefixes.PrefixSnapshotLeaderSchedule) {

--- a/lib/pos_epoch_complete_hook.go
+++ b/lib/pos_epoch_complete_hook.go
@@ -86,7 +86,7 @@ func (bav *UtxoView) RunEpochCompleteHook(blockHeight uint64) error {
 	// Snapshot the current validator set's total stake. Note, the validator set is already filtered to the top n
 	// active validators for the epoch. The total stake is the sum of all of the active validators' stakes.
 	globalActiveStakeAmountNanos := SumValidatorEntriesTotalStakeAmountNanos(validatorSet)
-	bav._setSnapshotGlobalActiveStakeAmountNanos(globalActiveStakeAmountNanos, currentEpochEntry.EpochNumber)
+	bav._setSnapshotValidatorSetTotalStakeAmountNanos(globalActiveStakeAmountNanos, currentEpochEntry.EpochNumber)
 
 	// Generate + snapshot a leader schedule.
 	leaderSchedule, err := bav.GenerateLeaderSchedule()

--- a/lib/pos_epoch_complete_hook_test.go
+++ b/lib/pos_epoch_complete_hook_test.go
@@ -159,10 +159,10 @@ func TestRunEpochCompleteHook(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, validatorEntries)
 
-		// Test SnapshotGlobalActiveStakeAmountNanos is zero.
-		snapshotGlobalActiveStakeAmountNanos, err := utxoView().GetSnapshotGlobalActiveStakeAmountNanos()
+		// Test SnapshotValidatorSetTotalStakeAmountNanos is zero.
+		snapshotValidatorSetTotalStakeAmountNanos, err := utxoView().GetSnapshotValidatorSetTotalStakeAmountNanos()
 		require.NoError(t, err)
-		require.True(t, snapshotGlobalActiveStakeAmountNanos.IsZero())
+		require.True(t, snapshotValidatorSetTotalStakeAmountNanos.IsZero())
 
 		// Test SnapshotLeaderSchedule is nil.
 		for index := range validatorPKIDs {
@@ -311,10 +311,10 @@ func TestRunEpochCompleteHook(t *testing.T) {
 		require.Equal(t, validatorEntries[0].TotalStakeAmountNanos, uint256.NewInt().SetUint64(700))
 		require.Equal(t, validatorEntries[6].TotalStakeAmountNanos, uint256.NewInt().SetUint64(100))
 
-		// Test SnapshotGlobalActiveStakeAmountNanos is populated.
-		snapshotGlobalActiveStakeAmountNanos, err := utxoView().GetSnapshotGlobalActiveStakeAmountNanos()
+		// Test SnapshotValidatorSetTotalStakeAmountNanos is populated.
+		snapshotValidatorSetTotalStakeAmountNanos, err := utxoView().GetSnapshotValidatorSetTotalStakeAmountNanos()
 		require.NoError(t, err)
-		require.Equal(t, snapshotGlobalActiveStakeAmountNanos, uint256.NewInt().SetUint64(2800))
+		require.Equal(t, snapshotValidatorSetTotalStakeAmountNanos, uint256.NewInt().SetUint64(2800))
 
 		// Test SnapshotLeaderSchedule is populated.
 		for index := range validatorPKIDs {


### PR DESCRIPTION
The snapshotted global active stake amount nanos now just represents the total stake of the validator set for an epoch. The new naming more clearly reflects that.