### PR TITLE
PoS Add RestakeRewards flag to TxnTypeStake

### DIFF
--- a/lib/block_view_stake.go
+++ b/lib/block_view_stake.go
@@ -35,6 +35,7 @@ import (
 type StakeEntry struct {
 	StakerPKID       *PKID
 	ValidatorPKID    *PKID
+	RestakeRewards   bool
 	StakeAmountNanos *uint256.Int
 	ExtraData        map[string][]byte
 	isDeleted        bool
@@ -49,6 +50,7 @@ func (stakeEntry *StakeEntry) Copy() *StakeEntry {
 	return &StakeEntry{
 		StakerPKID:       stakeEntry.StakerPKID.NewPKID(),
 		ValidatorPKID:    stakeEntry.ValidatorPKID.NewPKID(),
+		RestakeRewards:   stakeEntry.RestakeRewards,
 		StakeAmountNanos: stakeEntry.StakeAmountNanos.Clone(),
 		ExtraData:        copyExtraData(stakeEntry.ExtraData),
 		isDeleted:        stakeEntry.isDeleted,
@@ -70,6 +72,7 @@ func (stakeEntry *StakeEntry) RawEncodeWithoutMetadata(blockHeight uint64, skipM
 	var data []byte
 	data = append(data, EncodeToBytes(blockHeight, stakeEntry.StakerPKID, skipMetadata...)...)
 	data = append(data, EncodeToBytes(blockHeight, stakeEntry.ValidatorPKID, skipMetadata...)...)
+	data = append(data, BoolToByte(stakeEntry.RestakeRewards))
 	data = append(data, VariableEncodeUint256(stakeEntry.StakeAmountNanos)...)
 	data = append(data, EncodeExtraData(stakeEntry.ExtraData)...)
 	return data
@@ -88,6 +91,12 @@ func (stakeEntry *StakeEntry) RawDecodeWithoutMetadata(blockHeight uint64, rr *b
 	stakeEntry.ValidatorPKID, err = DecodeDeSoEncoder(&PKID{}, rr)
 	if err != nil {
 		return errors.Wrapf(err, "StakeEntry.Decode: Problem reading ValidatorPKID: ")
+	}
+
+	// RestakeRewards
+	stakeEntry.RestakeRewards, err = ReadBoolByte(rr)
+	if err != nil {
+		return errors.Wrapf(err, "StakeEntry.Decode: Problem reading RestakeRewards")
 	}
 
 	// StakeAmountNanos
@@ -215,6 +224,7 @@ func (lockedStakeEntry *LockedStakeEntry) GetEncoderType() EncoderType {
 
 type StakeMetadata struct {
 	ValidatorPublicKey *PublicKey
+	RestakeRewards     bool
 	StakeAmountNanos   *uint256.Int
 }
 
@@ -225,6 +235,7 @@ func (txnData *StakeMetadata) GetTxnType() TxnType {
 func (txnData *StakeMetadata) ToBytes(preSignature bool) ([]byte, error) {
 	var data []byte
 	data = append(data, EncodeByteArray(txnData.ValidatorPublicKey.ToBytes())...)
+	data = append(data, BoolToByte(txnData.RestakeRewards))
 	data = append(data, VariableEncodeUint256(txnData.StakeAmountNanos)...)
 	return data, nil
 }
@@ -238,6 +249,12 @@ func (txnData *StakeMetadata) FromBytes(data []byte) error {
 		return errors.Wrapf(err, "StakeMetadata.FromBytes: Problem reading ValidatorPublicKey: ")
 	}
 	txnData.ValidatorPublicKey = NewPublicKey(validatorPublicKeyBytes)
+
+	// RestakeRewards
+	txnData.RestakeRewards, err = ReadBoolByte(rr)
+	if err != nil {
+		return errors.Wrapf(err, "StakeMetadata.FromBytes: Problem reading RestakeRewards: ")
+	}
 
 	// StakeAmountNanos
 	txnData.StakeAmountNanos, err = VariableDecodeUint256(rr)
@@ -353,6 +370,7 @@ func (txnData *UnlockStakeMetadata) New() DeSoTxnMetadata {
 type StakeTxindexMetadata struct {
 	StakerPublicKeyBase58Check    string
 	ValidatorPublicKeyBase58Check string
+	RestakeRewards                bool
 	StakeAmountNanos              *uint256.Int
 }
 
@@ -360,6 +378,7 @@ func (txindexMetadata *StakeTxindexMetadata) RawEncodeWithoutMetadata(blockHeigh
 	var data []byte
 	data = append(data, EncodeByteArray([]byte(txindexMetadata.StakerPublicKeyBase58Check))...)
 	data = append(data, EncodeByteArray([]byte(txindexMetadata.ValidatorPublicKeyBase58Check))...)
+	data = append(data, BoolToByte(txindexMetadata.RestakeRewards))
 	data = append(data, VariableEncodeUint256(txindexMetadata.StakeAmountNanos)...)
 	return data
 }
@@ -380,6 +399,12 @@ func (txindexMetadata *StakeTxindexMetadata) RawDecodeWithoutMetadata(blockHeigh
 		return errors.Wrapf(err, "StakeTxindexMetadata.Decode: Problem reading ValidatorPublicKeyBase58Check: ")
 	}
 	txindexMetadata.ValidatorPublicKeyBase58Check = string(validatorPublicKeyBase58CheckBytes)
+
+	// RestakeRewards
+	txindexMetadata.RestakeRewards, err = ReadBoolByte(rr)
+	if err != nil {
+		return errors.Wrapf(err, "StakeTxindexMetadata.Decode: Problem reading RestakeRewards: ")
+	}
 
 	// StakeAmountNanos
 	txindexMetadata.StakeAmountNanos, err = VariableDecodeUint256(rr)
@@ -1202,6 +1227,7 @@ func (bav *UtxoView) _connectStake(
 	currentStakeEntry := &StakeEntry{
 		StakerPKID:       transactorPKIDEntry.PKID,
 		ValidatorPKID:    prevValidatorEntry.ValidatorPKID,
+		RestakeRewards:   txMeta.RestakeRewards,
 		StakeAmountNanos: stakeAmountNanos,
 		ExtraData:        mergeExtraData(prevExtraData, txn.ExtraData),
 	}

--- a/lib/block_view_stake.go
+++ b/lib/block_view_stake.go
@@ -1867,6 +1867,16 @@ func (bav *UtxoView) IsValidStakeMetadata(transactorPkBytes []byte, metadata *St
 		return errors.Wrapf(RuleErrorInvalidStakeInsufficientBalance, "UtxoView.IsValidStakeMetadata: ")
 	}
 
+	// Validate StakeAmountNanos > 0 when this is the first stake operation where the transactor is staking
+	// to the validator. It should not be possible for a validator to stake 0 DESO to a validator.
+	stakeEntry, err := bav.GetStakeEntry(validatorEntry.ValidatorPKID, transactorPKIDEntry.PKID)
+	if err != nil {
+		return errors.Wrapf(err, "UtxoView.IsValidStakeMetadata: ")
+	}
+	if stakeEntry == nil && metadata.StakeAmountNanos.IsZero() {
+		return errors.Wrapf(RuleErrorInvalidStakeAmountNanos, "UtxoView.IsValidStakeMetadata: ")
+	}
+
 	return nil
 }
 

--- a/lib/block_view_stake.go
+++ b/lib/block_view_stake.go
@@ -1852,13 +1852,11 @@ func (bav *UtxoView) IsValidStakeMetadata(transactorPkBytes []byte, metadata *St
 		return errors.Wrapf(RuleErrorInvalidStakeValidatorDisabledDelegatedStake, "UtxoView.IsValidStakeMetadata: ")
 	}
 
-	// Validate 0 < StakeAmountNanos <= transactor's DESO Balance. We ignore
+	// Validate 0 <= StakeAmountNanos <= transactor's DESO Balance. We ignore
 	// the txn fees in this check. The StakeAmountNanos will be validated to
 	// be less than the transactor's DESO balance net of txn fees in the call
 	// to connectBasicTransferWithExtraSpend.
-	if metadata.StakeAmountNanos == nil ||
-		metadata.StakeAmountNanos.IsZero() ||
-		!metadata.StakeAmountNanos.IsUint64() {
+	if metadata.StakeAmountNanos == nil || !metadata.StakeAmountNanos.IsUint64() {
 		return errors.Wrapf(RuleErrorInvalidStakeAmountNanos, "UtxoView.IsValidStakeMetadata: ")
 	}
 	transactorDeSoBalanceNanos, err := bav.GetSpendableDeSoBalanceNanosForPublicKey(transactorPkBytes, blockHeight-1)

--- a/lib/block_view_stake_test.go
+++ b/lib/block_view_stake_test.go
@@ -125,6 +125,7 @@ func _testStaking(t *testing.T, flushToDB bool) {
 
 		stakeMetadata := &StakeMetadata{
 			ValidatorPublicKey: NewPublicKey(m0PkBytes),
+			RestakeRewards:     false,
 			StakeAmountNanos:   uint256.NewInt().SetUint64(100),
 		}
 		_, err = _submitStakeTxn(
@@ -141,6 +142,7 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		// RuleErrorInvalidValidatorPKID
 		stakeMetadata := &StakeMetadata{
 			ValidatorPublicKey: NewPublicKey(m2PkBytes),
+			RestakeRewards:     false,
 			StakeAmountNanos:   uint256.NewInt(),
 		}
 		_, err = _submitStakeTxn(
@@ -153,19 +155,8 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		// RuleErrorInvalidStakeAmountNanos
 		stakeMetadata := &StakeMetadata{
 			ValidatorPublicKey: NewPublicKey(m0PkBytes),
+			RestakeRewards:     false,
 			StakeAmountNanos:   nil,
-		}
-		_, err = _submitStakeTxn(
-			testMeta, m1Pub, m1Priv, stakeMetadata, nil, flushToDB,
-		)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), RuleErrorInvalidStakeAmountNanos)
-	}
-	{
-		// RuleErrorInvalidStakeAmountNanos
-		stakeMetadata := &StakeMetadata{
-			ValidatorPublicKey: NewPublicKey(m0PkBytes),
-			StakeAmountNanos:   uint256.NewInt(),
 		}
 		_, err = _submitStakeTxn(
 			testMeta, m1Pub, m1Priv, stakeMetadata, nil, flushToDB,
@@ -189,6 +180,7 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		// RuleErrorInvalidStakeInsufficientBalance
 		stakeMetadata := &StakeMetadata{
 			ValidatorPublicKey: NewPublicKey(m0PkBytes),
+			RestakeRewards:     false,
 			StakeAmountNanos:   uint256.NewInt().SetUint64(math.MaxUint64),
 		}
 		_, err = _submitStakeTxn(
@@ -202,6 +194,7 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		m1OldDESOBalanceNanos := getDESOBalanceNanos(m1PkBytes)
 		stakeMetadata := &StakeMetadata{
 			ValidatorPublicKey: NewPublicKey(m0PkBytes),
+			RestakeRewards:     false,
 			StakeAmountNanos:   uint256.NewInt().SetUint64(100),
 		}
 		extraData := map[string][]byte{"TestKey": []byte("TestValue")}
@@ -214,6 +207,7 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		stakeEntry, err := utxoView().GetStakeEntry(m0PKID, m1PKID)
 		require.NoError(t, err)
 		require.NotNil(t, stakeEntry)
+		require.False(t, stakeEntry.RestakeRewards)
 		require.Equal(t, stakeEntry.StakeAmountNanos, uint256.NewInt().SetUint64(100))
 		require.Equal(t, stakeEntry.ExtraData["TestKey"], []byte("TestValue"))
 
@@ -232,6 +226,7 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		m1OldDESOBalanceNanos := getDESOBalanceNanos(m1PkBytes)
 		stakeMetadata := &StakeMetadata{
 			ValidatorPublicKey: NewPublicKey(m0PkBytes),
+			RestakeRewards:     false,
 			StakeAmountNanos:   uint256.NewInt().SetUint64(50),
 		}
 		extraData := map[string][]byte{"TestKey": []byte("TestValue2")}
@@ -244,10 +239,45 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		stakeEntry, err := utxoView().GetStakeEntry(m0PKID, m1PKID)
 		require.NoError(t, err)
 		require.NotNil(t, stakeEntry)
+		require.False(t, stakeEntry.RestakeRewards)
 		require.Equal(t, stakeEntry.StakeAmountNanos, uint256.NewInt().SetUint64(150))
 		require.Equal(t, stakeEntry.ExtraData["TestKey"], []byte("TestValue2"))
 
 		// Verify ValidatorEntry.TotalStakeAmountNanos.
+		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
+		require.NoError(t, err)
+		require.NotNil(t, validatorEntry)
+		require.Equal(t, validatorEntry.TotalStakeAmountNanos, uint256.NewInt().SetUint64(150))
+
+		// Verify m1's DESO balance decreases by StakeAmountNanos (net of fees).
+		m1NewDESOBalanceNanos := getDESOBalanceNanos(m1PkBytes)
+		require.Equal(t, m1OldDESOBalanceNanos-feeNanos-stakeMetadata.StakeAmountNanos.Uint64(), m1NewDESOBalanceNanos)
+	}
+	{
+		// m1 changes the RestakeRewards flag on their stake with m0.
+		m1OldDESOBalanceNanos := getDESOBalanceNanos(m1PkBytes)
+		stakeMetadata := &StakeMetadata{
+			ValidatorPublicKey: NewPublicKey(m0PkBytes),
+			RestakeRewards:     true,
+			StakeAmountNanos:   uint256.NewInt(),
+		}
+		extraData := map[string][]byte{"TestKey": []byte("TestValue2")}
+		feeNanos, err := _submitStakeTxn(
+			testMeta, m1Pub, m1Priv, stakeMetadata, extraData, flushToDB,
+		)
+		require.NoError(t, err)
+
+		// Verify the StakeEntry.StakeAmountNanos does not change.
+		stakeEntry, err := utxoView().GetStakeEntry(m0PKID, m1PKID)
+		require.NoError(t, err)
+		require.NotNil(t, stakeEntry)
+		require.Equal(t, stakeEntry.StakeAmountNanos, uint256.NewInt().SetUint64(150))
+		require.Equal(t, stakeEntry.ExtraData["TestKey"], []byte("TestValue2"))
+
+		// Verify the StakeEntry.RestakeRewards flag is updated to true.
+		require.True(t, stakeEntry.RestakeRewards)
+
+		// Verify the ValidatorEntry.TotalStakeAmountNanos does not change.
 		validatorEntry, err := utxoView().GetValidatorByPKID(m0PKID)
 		require.NoError(t, err)
 		require.NotNil(t, validatorEntry)

--- a/lib/block_view_stake_test.go
+++ b/lib/block_view_stake_test.go
@@ -168,6 +168,18 @@ func _testStaking(t *testing.T, flushToDB bool) {
 		// RuleErrorInvalidStakeAmountNanos
 		stakeMetadata := &StakeMetadata{
 			ValidatorPublicKey: NewPublicKey(m0PkBytes),
+			StakeAmountNanos:   uint256.NewInt(),
+		}
+		_, err = _submitStakeTxn(
+			testMeta, m1Pub, m1Priv, stakeMetadata, nil, flushToDB,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), RuleErrorInvalidStakeAmountNanos)
+	}
+	{
+		// RuleErrorInvalidStakeAmountNanos
+		stakeMetadata := &StakeMetadata{
+			ValidatorPublicKey: NewPublicKey(m0PkBytes),
 			StakeAmountNanos:   MaxUint256,
 		}
 		_, err = _submitStakeTxn(


### PR DESCRIPTION
Changes in this PR:
- Added a RestakeRewards flag to the Stake txn type and the StakeEntry

Expected flow for staking:
- When a transactor first stakes, they need to provide a non-zero stake amount
- Once a transactor has staked, they can add to their stake by submitting a Stake txn with non-zero stake amounts
- Once a transactor has staked, they can change their RestakeRewards flag by submitting a Stake txn with the new flag value. If the stake amount in the txn is zero, then it won't change the stake amount; if it's non-zero, it will also increase their stake amount