### PR TITLE
Implement Fast-HotStuff Block Construction Signal

### DIFF
--- a/consensus/event_loop.go
+++ b/consensus/event_loop.go
@@ -454,7 +454,7 @@ func (fc *FastHotStuffEventLoop) onBlockConstructionScheduledTaskExecuted(blockC
 			BlockHeight: fc.tip.block.GetHeight() + 1,      // The next block height
 			QC: &quorumCertificate{
 				blockHash: fc.tip.block.GetBlockHash(), // Block hash for the tip, which we are extending from
-				view:      fc.tip.block.GetView(),      // The view from the tip block. This is always currentView - 1
+				view:      fc.tip.block.GetView(),      // The view from the tip block. This is always fc.currentView - 1
 				aggregatedSignature: &aggregatedSignature{
 					signersList: signersList, // The signers list who voted on the tip block
 					signature:   signature,   // Aggregated signature from votes on the tip block
@@ -476,11 +476,11 @@ func (fc *FastHotStuffEventLoop) onBlockConstructionScheduledTaskExecuted(blockC
 }
 
 // tryConstructVoteQCInCurrentView is a helper function that attempts to construct a QC for the tip block
-// so that can be proposed in a block in the current view. The function internally performs all view and vote
+// so that it can be proposed in a block in the current view. The function internally performs all view and vote
 // validations to ensure that the resulting QC is valid. If a QC can be constructed, the function returns
 // the signers list and aggregate signature that can be used to construct the QC.
 //
-// This function must be called while holding the consensus instance's lock held.
+// This function must be called while holding the consensus instance's lock.
 func (fc *FastHotStuffEventLoop) tryConstructVoteQCInCurrentView() (
 	_success bool, // true if and only if we are able to construct a vote QC for the tip block in the current view
 	_signersList *bitset.Bitset, // bitset of signers for the aggregated signature for the tip block
@@ -526,7 +526,7 @@ func (fc *FastHotStuffEventLoop) tryConstructVoteQCInCurrentView() (
 			continue
 		}
 
-		// Track the votes signature, stake, and place in the validator set
+		// Track the vote's signature, stake, and place in the validator set
 		totalVotingStake = uint256.NewInt().Add(totalVotingStake, validator.GetStakeAmount())
 		signersList.Set(ii, true)
 		signatures = append(signatures, vote.GetSignature())

--- a/consensus/event_loop.go
+++ b/consensus/event_loop.go
@@ -3,10 +3,12 @@ package consensus
 import (
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
 
 	"github.com/deso-protocol/core/bls"
 	"github.com/deso-protocol/core/collections"
+	"github.com/deso-protocol/core/collections/bitset"
 )
 
 func NewFastHotStuffEventLoop() *FastHotStuffEventLoop {
@@ -415,14 +417,135 @@ func (fc *FastHotStuffEventLoop) resetScheduledTasks() {
 	}
 
 	// Schedule the next block construction task. This will run with currentView param.
-	fc.nextBlockConstructionTask.Schedule(fc.blockConstructionInterval, fc.currentView, fc.onBlockConstructionScheduledTask)
+	fc.nextBlockConstructionTask.Schedule(fc.blockConstructionInterval, fc.currentView, fc.onBlockConstructionScheduledTaskExecuted)
 
 	// Schedule the next timeout task. This will run with currentView param.
 	fc.nextTimeoutTask.Schedule(timeoutDuration, fc.currentView, fc.onTimeoutScheduledTaskExecuted)
 }
 
-func (fc *FastHotStuffEventLoop) onBlockConstructionScheduledTask(blockConstructionView uint64) {
-	// TODO
+// When this function is triggered, it means that we have reached the block construction
+// time ETA for blockConstructionView. If we have a QC or timeout QC for the view, then we
+// signal the server.
+func (fc *FastHotStuffEventLoop) onBlockConstructionScheduledTaskExecuted(blockConstructionView uint64) {
+	fc.lock.Lock()
+	defer fc.lock.Unlock()
+
+	// Check if the consensus instance is running. If it's not running, then there's nothing
+	// to do here.
+	if fc.status != consensusStatusRunning {
+		return
+	}
+
+	// Check for race conditions where the view advanced at the exact moment this task began
+	// or we have already signaled for this view. If so, then there's nothing to do here.
+	if fc.currentView != blockConstructionView {
+		return
+	}
+
+	// Check if the conditions are met to construct a QC from votes for the chain tip. If so,
+	// we send a signal to the server and cancel the block construction task. The server will
+	// reschedule the task when it advances the view.
+	if canConstructQC, signersList, signature := fc.tryConstructVoteQCInCurrentView(); canConstructQC {
+		// Signal the server that we can construct a QC for the chain tip
+		fc.ConsensusEvents <- &ConsensusEvent{
+			EventType:   ConsensusEventTypeConstructVoteQC, // The event type
+			View:        fc.currentView,                    // The current view in which we can construct a block
+			BlockHash:   fc.tip.block.GetBlockHash(),       // Block hash for the tip, which we are extending from
+			BlockHeight: fc.tip.block.GetHeight() + 1,      // The next block height
+			QC: &quorumCertificate{
+				blockHash: fc.tip.block.GetBlockHash(), // Block hash for the tip, which we are extending from
+				view:      fc.tip.block.GetView(),      // The view from the tip block. This is always currentView - 1
+				aggregatedSignature: &aggregatedSignature{
+					signersList: signersList, // The signers list who voted on the tip block
+					signature:   signature,   // Aggregated signature from votes on the tip block
+				},
+			},
+		}
+
+		// Cancel the block construction task since we know we can construct a QC in the current view.
+		// It will be rescheduled when we advance view.
+		fc.nextBlockConstructionTask.Cancel()
+
+		return
+	}
+
+	// TODO: Check if we can construct a timeout QC for the current view, and send the signal to the
+	// server
+
+	return
+}
+
+// tryConstructVoteQCInCurrentView is a helper function that attempts to construct a QC for the tip block
+// so that can be proposed in a block in the current view. The function internally performs all view and vote
+// validations to ensure that the resulting QC is valid. If a QC can be constructed, the function returns
+// the signers list and aggregate signature that can be used to construct the QC.
+//
+// This function must be called while holding the consensus instance's lock held.
+func (fc *FastHotStuffEventLoop) tryConstructVoteQCInCurrentView() (
+	_success bool, // true if and only if we are able to construct a vote QC for the tip block in the current view
+	_signersList *bitset.Bitset, // bitset of signers for the aggregated signature for the tip block
+	_aggregateSignature *bls.Signature, // aggregated signature for the tip block
+) {
+	// If currentView != tipBlock.View + 1, then we have timed out at some point, and can no longer
+	// construct a block with a QC of votes for the tip block.
+	tipBlock := fc.tip.block
+	if fc.currentView != tipBlock.GetView()+1 {
+		return false, nil, nil
+	}
+
+	// Fetch the validator set at the tip.
+	validatorSet := fc.tip.validatorSet
+
+	// Compute the chain tip's signature payload.
+	voteSignaturePayload := GetVoteSignaturePayload(tipBlock.GetView(), tipBlock.GetBlockHash())
+
+	// Fetch the validator votes for the tip block.
+	votesByValidator := fc.votesSeen[voteSignaturePayload]
+
+	// Compute the total stake and total stake with votes
+	totalStake := uint256.NewInt()
+	totalVotingStake := uint256.NewInt()
+
+	// Track the signatures and signers list for the chain tip
+	signersList := bitset.NewBitset()
+	signatures := []*bls.Signature{}
+
+	// Iterate through the entire validator set and check if each one has voted for the tip block. Track
+	// all voters and their stakes.
+	for ii, validator := range validatorSet {
+		totalStake = uint256.NewInt().Add(totalStake, validator.GetStakeAmount())
+
+		// Skip the validator if it hasn't voted for the the block
+		vote, hasVoted := votesByValidator[validator.GetPublicKey().ToString()]
+		if !hasVoted {
+			continue
+		}
+
+		// Verify the vote signature
+		if !isValidSignatureSinglePublicKey(vote.GetPublicKey(), vote.GetSignature(), voteSignaturePayload[:]) {
+			continue
+		}
+
+		// Track the votes signature, stake, and place in the validator set
+		totalVotingStake = uint256.NewInt().Add(totalVotingStake, validator.GetStakeAmount())
+		signersList.Set(ii, true)
+		signatures = append(signatures, vote.GetSignature())
+	}
+
+	// If we don't have a super-majority vote for the chain tip, then we can't build a QC.
+	if !isSuperMajorityStake(totalVotingStake, totalStake) {
+		return false, nil, nil
+	}
+
+	// If we reach this point, then we have enough signatures to build a QC for the tip block. Try to
+	// aggregate the signatures. This should never fail.
+	aggregateSignature, err := bls.AggregateSignatures(signatures)
+	if err != nil {
+		return false, nil, nil
+	}
+
+	// Happy path
+	return true, signersList, aggregateSignature
 }
 
 // When this function is triggered, it means that we have reached out the timeout ETA for the

--- a/consensus/event_loop_test.go
+++ b/consensus/event_loop_test.go
@@ -530,7 +530,7 @@ func TestTimeoutScheduledTaskExecuted(t *testing.T) {
 	// Confirm that the timeout signal is for the the expected view
 	require.Equal(t, timeoutSignal.EventType, ConsensusEventTypeTimeout)
 	require.Equal(t, timeoutSignal.View, dummyBlock.GetView()+1)
-	require.Equal(t, timeoutSignal.BlockHash.GetValue(), dummyBlock.GetBlockHash().GetValue())
+	require.Equal(t, timeoutSignal.TipBlockHash.GetValue(), dummyBlock.GetBlockHash().GetValue())
 
 	// Confirm that the timeout is no longer running
 	require.False(t, fc.nextTimeoutTask.IsScheduled())
@@ -544,7 +544,7 @@ func TestTimeoutScheduledTaskExecuted(t *testing.T) {
 	// Confirm that the timeout signal is for the the expected view
 	require.Equal(t, timeoutSignal.EventType, ConsensusEventTypeTimeout)
 	require.Equal(t, timeoutSignal.View, dummyBlock.GetView()+2)
-	require.Equal(t, timeoutSignal.BlockHash.GetValue(), dummyBlock.GetBlockHash().GetValue())
+	require.Equal(t, timeoutSignal.TipBlockHash.GetValue(), dummyBlock.GetBlockHash().GetValue())
 
 	// Confirm that the timeout is no longer running
 	require.False(t, fc.nextTimeoutTask.IsScheduled())
@@ -701,8 +701,8 @@ func TestVoteQCConstructionSignal(t *testing.T) {
 		// Confirm that the block construction signal has the expected parameters
 		require.Equal(t, blockConstructionSignal.EventType, ConsensusEventTypeConstructVoteQC)
 		require.Equal(t, blockConstructionSignal.View, block.GetView()+1)
-		require.Equal(t, blockConstructionSignal.BlockHash.GetValue(), block.GetBlockHash().GetValue())
-		require.Equal(t, blockConstructionSignal.BlockHeight, block.GetHeight()+1)
+		require.Equal(t, blockConstructionSignal.TipBlockHash.GetValue(), block.GetBlockHash().GetValue())
+		require.Equal(t, blockConstructionSignal.TipBlockHeight, block.GetHeight()+1)
 		require.Equal(t, blockConstructionSignal.QC.GetView(), block.GetView())
 		require.Equal(t, blockConstructionSignal.QC.GetBlockHash().GetValue(), block.GetBlockHash().GetValue())
 		require.Equal(t, blockConstructionSignal.QC.GetAggregatedSignature().GetSignersList().ToBytes(), bitset.NewBitset().Set(0, true).ToBytes())

--- a/consensus/event_loop_test.go
+++ b/consensus/event_loop_test.go
@@ -702,7 +702,7 @@ func TestVoteQCConstructionSignal(t *testing.T) {
 		require.Equal(t, blockConstructionSignal.EventType, ConsensusEventTypeConstructVoteQC)
 		require.Equal(t, blockConstructionSignal.View, block.GetView()+1)
 		require.Equal(t, blockConstructionSignal.TipBlockHash.GetValue(), block.GetBlockHash().GetValue())
-		require.Equal(t, blockConstructionSignal.TipBlockHeight, block.GetHeight()+1)
+		require.Equal(t, blockConstructionSignal.TipBlockHeight, block.GetHeight())
 		require.Equal(t, blockConstructionSignal.QC.GetView(), block.GetView())
 		require.Equal(t, blockConstructionSignal.QC.GetBlockHash().GetValue(), block.GetBlockHash().GetValue())
 		require.Equal(t, blockConstructionSignal.QC.GetAggregatedSignature().GetSignersList().ToBytes(), bitset.NewBitset().Set(0, true).ToBytes())

--- a/consensus/event_loop_test.go
+++ b/consensus/event_loop_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deso-protocol/core/bls"
+	"github.com/deso-protocol/core/collections/bitset"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -593,6 +596,118 @@ func TestResetEventLoopSignal(t *testing.T) {
 
 	// Stop the event loop
 	fc.Stop()
+}
+
+func TestVoteQCConstructionSignal(t *testing.T) {
+
+	// Create a valid dummy block at view 2
+	block := createDummyBlock(2)
+
+	// Create a valid validator set
+	validatorPrivateKey1, _ := bls.NewPrivateKey()
+	validatorPrivateKey2, _ := bls.NewPrivateKey()
+
+	validatorSet := []Validator{
+		&validator{
+			publicKey:   validatorPrivateKey1.PublicKey(),
+			stakeAmount: uint256.NewInt().SetUint64(70),
+		},
+		&validator{
+			publicKey:   validatorPrivateKey2.PublicKey(),
+			stakeAmount: uint256.NewInt().SetUint64(30),
+		},
+	}
+
+	voteSignaturePayload := GetVoteSignaturePayload(2, block.GetBlockHash())
+
+	validator1Vote, _ := validatorPrivateKey1.Sign(voteSignaturePayload[:])
+	validator2Vote, _ := validatorPrivateKey2.Sign(voteSignaturePayload[:])
+
+	// Sad path, not enough votes to construct a QC
+	{
+		fc := NewFastHotStuffEventLoop()
+		err := fc.Init(time.Microsecond, time.Hour,
+			BlockWithValidators{block, validatorSet},     // tip
+			[]BlockWithValidators{{block, validatorSet}}, // safeBlocks
+		)
+		require.NoError(t, err)
+
+		// Create a vote from validator 2
+		vote := voteMessage{
+			view:      2,                                // The view the block was proposed in
+			blockHash: block.GetBlockHash(),             // Block hash is the same as the block hash of the dummy block
+			publicKey: validatorPrivateKey2.PublicKey(), // Validator 2 with 30/100 stake votes
+			signature: validator2Vote,                   // Validator 2's vote
+		}
+
+		// Store the vote in the event loop's votesSeen map
+		fc.votesSeen[voteSignaturePayload] = map[string]VoteMessage{
+			vote.publicKey.ToString(): &vote,
+		}
+
+		// Start the event loop
+		fc.Start()
+
+		// Wait up to 100 milliseconds for a block construction signal to be sent
+		select {
+		case <-fc.ConsensusEvents:
+			require.Fail(t, "Received a block construction signal when there were not enough votes to construct a QC")
+		case <-time.After(100 * time.Millisecond):
+			// Do nothing
+		}
+
+		// Stop the event loop
+		fc.Stop()
+	}
+
+	// Happy path, there are votes with a super-majority of stake to construct a QC
+	{
+		fc := NewFastHotStuffEventLoop()
+		err := fc.Init(time.Microsecond, time.Hour,
+			BlockWithValidators{block, validatorSet},     // tip
+			[]BlockWithValidators{{block, validatorSet}}, // safeBlocks
+		)
+		require.NoError(t, err)
+
+		// Create a vote from validator 2
+		vote := voteMessage{
+			view:      2,                                // The view the block was proposed in
+			blockHash: block.GetBlockHash(),             // Block hash is the same as the block hash of the dummy block
+			publicKey: validatorPrivateKey1.PublicKey(), // Validator 1 with 70/100 stake votes
+			signature: validator1Vote,                   // Validator 1's vote
+		}
+
+		// Store the vote in the event loop's votesSeen map
+		fc.votesSeen[voteSignaturePayload] = map[string]VoteMessage{
+			vote.publicKey.ToString(): &vote,
+		}
+
+		// Start the event loop
+		fc.Start()
+
+		var blockConstructionSignal *ConsensusEvent
+
+		// Wait up to 100 milliseconds for a block construction signal to be sent
+		select {
+		case blockConstructionSignal = <-fc.ConsensusEvents:
+			// Do nothing
+		case <-time.After(100 * time.Millisecond):
+			require.Fail(t, "Did not receive a block construction signal when there were enough votes to construct a QC")
+		}
+
+		// Stop the event loop
+		fc.Stop()
+
+		// Confirm that the block construction signal has the expected parameters
+		require.Equal(t, blockConstructionSignal.EventType, ConsensusEventTypeConstructVoteQC)
+		require.Equal(t, blockConstructionSignal.View, block.GetView()+1)
+		require.Equal(t, blockConstructionSignal.BlockHash.GetValue(), block.GetBlockHash().GetValue())
+		require.Equal(t, blockConstructionSignal.BlockHeight, block.GetHeight()+1)
+		require.Equal(t, blockConstructionSignal.QC.GetView(), block.GetView())
+		require.Equal(t, blockConstructionSignal.QC.GetBlockHash().GetValue(), block.GetBlockHash().GetValue())
+		require.Equal(t, blockConstructionSignal.QC.GetAggregatedSignature().GetSignersList().ToBytes(), bitset.NewBitset().Set(0, true).ToBytes())
+		require.Equal(t, blockConstructionSignal.QC.GetAggregatedSignature().GetSignature().ToBytes(), validator1Vote.ToBytes())
+	}
 }
 
 func TestFastHotStuffEventLoopStartStop(t *testing.T) {

--- a/consensus/event_loop_test.go
+++ b/consensus/event_loop_test.go
@@ -669,7 +669,7 @@ func TestVoteQCConstructionSignal(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Create a vote from validator 2
+		// Create a vote from validator 1
 		vote := voteMessage{
 			view:      2,                                // The view the block was proposed in
 			blockHash: block.GetBlockHash(),             // Block hash is the same as the block hash of the dummy block

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -28,11 +28,11 @@ const (
 )
 
 type ConsensusEvent struct {
-	EventType   ConsensusEventType
-	BlockHash   BlockHash
-	BlockHeight uint64
-	View        uint64
-	QC          QuorumCertificate
+	EventType      ConsensusEventType
+	TipBlockHash   BlockHash
+	TipBlockHeight uint64
+	View           uint64
+	QC             QuorumCertificate
 }
 
 // BlockHash is a 32-byte hash of a block used to uniquely identify a block. It's re-defined here

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -32,13 +32,14 @@ type ConsensusEvent struct {
 	BlockHash   BlockHash
 	BlockHeight uint64
 	View        uint64
+	QC          QuorumCertificate
 }
 
 // BlockHash is a 32-byte hash of a block used to uniquely identify a block. It's re-defined here
 // as an interface that matches the exact structure of the BlockHash type in core, so that the two
-// packages are decoupled and the Fast HotStuff consensus can be tested end-to-end independently.
-// When using the Fast HotStuff, the lib package can convert its own BlockHash type to and from this
-// type trivially.
+// packages are decoupled and the Fast HotStuff event loop can be tested end-to-end independently.
+// When using the Fast HotStuff event loop, the lib package can convert its own BlockHash type to
+// and from this type trivially.
 type BlockHash interface {
 	GetValue() [32]byte
 }
@@ -166,7 +167,7 @@ type FastHotStuffEventLoop struct {
 	// votesSeen is an in-memory map of all the votes we've seen so far. It's a nested map with the
 	// following nested key structure:
 	//
-	//   sha256(vote.View, vote.BlockHash) - > string(vote.PublicKey) -> VoteMessage
+	//   sha3-256(vote.View, vote.BlockHash) - > string(vote.PublicKey) -> VoteMessage
 	//
 	// We use a nested map as above because we want to be able to efficiently fetch all votes by block hash.
 	votesSeen map[[32]byte]map[string]VoteMessage

--- a/consensus/types_internal.go
+++ b/consensus/types_internal.go
@@ -67,7 +67,7 @@ func (qc *aggregateQuorumCertificate) GetAggregatedSignature() AggregatedSignatu
 //////////////////////////////////////////////////////////
 
 type quorumCertificate struct {
-	blockHash           *blockHash
+	blockHash           BlockHash
 	view                uint64
 	aggregatedSignature AggregatedSignature
 }
@@ -106,10 +106,10 @@ func (as *aggregatedSignature) GetSignature() *bls.Signature {
 //////////////////////////////////////////////////////////
 
 type block struct {
-	blockHash *blockHash
+	blockHash BlockHash
 	height    uint64
 	view      uint64
-	qc        *quorumCertificate
+	qc        QuorumCertificate
 }
 
 func (b *block) GetBlockHash() BlockHash {
@@ -134,7 +134,7 @@ func (b *block) GetQC() QuorumCertificate {
 
 type voteMessage struct {
 	view      uint64
-	blockHash *blockHash
+	blockHash BlockHash
 	publicKey *bls.PublicKey
 	signature *bls.Signature
 }
@@ -161,7 +161,7 @@ func (vm *voteMessage) GetSignature() *bls.Signature {
 
 type timeoutMessage struct {
 	view      uint64
-	highQC    *quorumCertificate
+	highQC    QuorumCertificate
 	publicKey *bls.PublicKey
 	signature *bls.Signature
 }

--- a/consensus/utils_test.go
+++ b/consensus/utils_test.go
@@ -363,12 +363,25 @@ func createDummyTimeoutMessage(view uint64) *timeoutMessage {
 }
 
 func createDummyQC(view uint64) *quorumCertificate {
+	blockHash := createDummyBlockHash()
+
+	signaturePayload := GetVoteSignaturePayload(view, blockHash)
+
+	blsPrivateKey1, _ := bls.NewPrivateKey()
+	blsSignature1, _ := blsPrivateKey1.Sign(signaturePayload[:])
+
+	blsPrivateKey2, _ := bls.NewPrivateKey()
+	blsSignature2, _ := blsPrivateKey2.Sign(signaturePayload[:])
+
+	signersList := bitset.NewBitset().Set(0, true).Set(1, true)
+	aggregateSignature, _ := bls.AggregateSignatures([]*bls.Signature{blsSignature1, blsSignature2})
+
 	return &quorumCertificate{
-		blockHash: createDummyBlockHash(),
+		blockHash: blockHash,
 		view:      view,
 		aggregatedSignature: &aggregatedSignature{
-			signersList: bitset.NewBitset().FromBytes([]byte{0x3}),
-			signature:   createDummyBLSSignature(),
+			signersList: signersList,
+			signature:   aggregateSignature,
 		},
 	}
 }

--- a/lib/server.go
+++ b/lib/server.go
@@ -2299,7 +2299,7 @@ func (srv *Server) _startConsensus() {
 		select {
 		case consensusEvent := <-srv.fastHotStuffEventLoop.ConsensusEvents:
 			{
-				glog.Infof("Server._startConsensus: Received consensus event for block height: %v", consensusEvent.BlockHeight)
+				glog.Infof("Server._startConsensus: Received consensus event for block height: %v", consensusEvent.TipBlockHeight)
 				srv._handleFastHostStuffConsensusEvent(consensusEvent)
 			}
 


### PR DESCRIPTION
The crank timer periodically checks if the event loop is able to construct a block in the current view. If it can, it constructs the QC and signals the server with the result.