### PR TITLE
introduce-committed-status-to-block-node

### DIFF
--- a/lib/block_view_bitcoin_test.go
+++ b/lib/block_view_bitcoin_test.go
@@ -49,7 +49,7 @@ func GetTestParamsCopy(
 	// Set the BitcoinExchange-related params to canned values.
 	paramsCopy := *paramss
 	headerHash := (BlockHash)(startHeader.BlockHash())
-	paramsCopy.BitcoinStartBlockNode = NewBlockNode(
+	paramsCopy.BitcoinStartBlockNode = NewPoWBlockNode(
 		nil,         /*ParentNode*/
 		&headerHash, /*Hash*/
 		startHeight,

--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -114,10 +114,9 @@ const (
 	EncoderTypeStakeEntry                        EncoderType = 41
 	EncoderTypeLockedStakeEntry                  EncoderType = 42
 	EncoderTypeEpochEntry                        EncoderType = 43
-	EncoderTypeBlockNode                         EncoderType = 44
 
 	// EncoderTypeEndBlockView encoder type should be at the end and is used for automated tests.
-	EncoderTypeEndBlockView EncoderType = 45
+	EncoderTypeEndBlockView EncoderType = 44
 )
 
 // Txindex encoder types.

--- a/lib/block_view_types.go
+++ b/lib/block_view_types.go
@@ -114,9 +114,10 @@ const (
 	EncoderTypeStakeEntry                        EncoderType = 41
 	EncoderTypeLockedStakeEntry                  EncoderType = 42
 	EncoderTypeEpochEntry                        EncoderType = 43
+	EncoderTypeBlockNode                         EncoderType = 44
 
 	// EncoderTypeEndBlockView encoder type should be at the end and is used for automated tests.
-	EncoderTypeEndBlockView EncoderType = 44
+	EncoderTypeEndBlockView EncoderType = 45
 )
 
 // Txindex encoder types.

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -298,8 +298,8 @@ func (nn *BlockNode) String() string {
 	if nn.Header != nil {
 		tstamp = uint32(nn.Header.GetTstampSecs())
 	}
-	return fmt.Sprintf("< TstampSecs: %d, Height: %d, Hash: %s, ParentHash %s, Status: %s, CumWork: %v>",
-		tstamp, nn.Header.Height, nn.Hash, parentHash, nn.Status, nn.CumWork)
+	return fmt.Sprintf("< TstampSecs: %d, Height: %d, Hash: %s, ParentHash %s, Status: %s, CumWork: %v, CommittedStatus: %v>",
+		tstamp, nn.Header.Height, nn.Hash, parentHash, nn.Status, nn.CumWork, nn.CommittedStatus)
 }
 
 // NewPoWBlockNode is a helper function to create a BlockNode
@@ -334,21 +334,17 @@ func NewPoSBlockNode(
 	parent *BlockNode,
 	hash *BlockHash,
 	height uint32,
-	difficultyTarget *BlockHash,
-	cumWork *big.Int,
 	header *MsgDeSoHeader,
 	status BlockStatus,
 	committedStatus CommittedBlockStatus) *BlockNode {
 
 	return &BlockNode{
-		Parent:           parent,
-		Hash:             hash,
-		Height:           height,
-		DifficultyTarget: difficultyTarget,
-		CumWork:          cumWork,
-		Header:           header,
-		Status:           status,
-		CommittedStatus:  committedStatus,
+		Parent:          parent,
+		Hash:            hash,
+		Height:          height,
+		Header:          header,
+		Status:          status,
+		CommittedStatus: committedStatus,
 	}
 }
 

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -75,6 +75,13 @@ const (
 	StatusBitcoinHeaderValidateFailed // Deprecated
 )
 
+type CommittedBlockStatus uint8
+
+const (
+	COMMITTED   CommittedBlockStatus = 0
+	UNCOMMITTED CommittedBlockStatus = 1
+)
+
 // IsFullyProcessed determines if the BlockStatus corresponds to a fully processed and stored block.
 func (blockStatus BlockStatus) IsFullyProcessed() bool {
 	return blockStatus&StatusHeaderValidated != 0 &&
@@ -149,6 +156,16 @@ type BlockNode struct {
 	// Status holds the validation state for the block and whether or not
 	// it's stored in the database.
 	Status BlockStatus
+
+	// CommittedStatus is either COMMITTED or UNCOMMITTED. If it's UNCOMMITTED, then
+	// the block is not yet committed to the blockchain. If it's COMMITTED, then the
+	// block is committed to the blockchain.
+	// In PoW consensus, all blocks will have CommittedStatus = COMMITTED.
+	// In PoS consensus, the chain tip and its parent will have CommittedStatus = UNCOMMITTED and
+	// all other blocks will have CommittedStatus = COMMITTED. When a new block is added to the tip,
+	// its CommittedStatus will be set to UNCOMMITTED and its grandparent's CommittedStatus will be
+	// updated to COMMITTED.
+	CommittedStatus CommittedBlockStatus
 }
 
 func _difficultyBitsToHash(diffBits uint32) (_diffHash *BlockHash) {
@@ -285,8 +302,11 @@ func (nn *BlockNode) String() string {
 		tstamp, nn.Header.Height, nn.Hash, parentHash, nn.Status, nn.CumWork)
 }
 
+// NewPoWBlockNode is a helper function to create a BlockNode
+// when running PoW consensus. All blocks in the PoW consensus
+// have a committed status of COMMITTED.
 // TODO: Height not needed in this since it's in the header.
-func NewBlockNode(
+func NewPoWBlockNode(
 	parent *BlockNode,
 	hash *BlockHash,
 	height uint32,
@@ -303,6 +323,32 @@ func NewBlockNode(
 		CumWork:          cumWork,
 		Header:           header,
 		Status:           status,
+		// All blocks have a committed status in PoW.
+		CommittedStatus: COMMITTED,
+	}
+}
+
+// NewPoSBlockNode is a new helper function to create a block node
+// as we need to control the value of the CommittedStatus field.
+func NewPoSBlockNode(
+	parent *BlockNode,
+	hash *BlockHash,
+	height uint32,
+	difficultyTarget *BlockHash,
+	cumWork *big.Int,
+	header *MsgDeSoHeader,
+	status BlockStatus,
+	committedStatus CommittedBlockStatus) *BlockNode {
+
+	return &BlockNode{
+		Parent:           parent,
+		Hash:             hash,
+		Height:           height,
+		DifficultyTarget: difficultyTarget,
+		CumWork:          cumWork,
+		Header:           header,
+		Status:           status,
+		CommittedStatus:  committedStatus,
 	}
 }
 
@@ -1724,7 +1770,7 @@ func (bc *Blockchain) processHeaderPoW(blockHeader *MsgDeSoHeader, headerHash *B
 	// and try to mine on top of it before revealing it to everyone.
 	newWork := BytesToBigint(ExpectedWorkForBlockHash(diffTarget)[:])
 	cumWork := newWork.Add(newWork, parentNode.CumWork)
-	newNode := NewBlockNode(
+	newNode := NewPoWBlockNode(
 		parentNode,
 		headerHash,
 		uint32(blockHeader.Height),

--- a/lib/blockchain_test.go
+++ b/lib/blockchain_test.go
@@ -1239,7 +1239,7 @@ func TestCalcNextDifficultyTargetHalvingDoublingHitLimit(t *testing.T) {
 		}
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),
@@ -1276,7 +1276,7 @@ func TestCalcNextDifficultyTargetHalvingDoublingHitLimit(t *testing.T) {
 		lastNode := nodes[ii-1]
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),
@@ -1335,7 +1335,7 @@ func TestCalcNextDifficultyTargetHittingLimitsSlow(t *testing.T) {
 		}
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),
@@ -1372,7 +1372,7 @@ func TestCalcNextDifficultyTargetHittingLimitsSlow(t *testing.T) {
 		lastNode := nodes[ii-1]
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),
@@ -1431,7 +1431,7 @@ func TestCalcNextDifficultyTargetHittingLimitsFast(t *testing.T) {
 		}
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),
@@ -1486,7 +1486,7 @@ func TestCalcNextDifficultyTargetJustRight(t *testing.T) {
 		}
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),
@@ -1541,7 +1541,7 @@ func TestCalcNextDifficultyTargetSlightlyOff(t *testing.T) {
 		}
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),
@@ -1578,7 +1578,7 @@ func TestCalcNextDifficultyTargetSlightlyOff(t *testing.T) {
 		lastNode := nodes[ii-1]
 		nextDiff, err := CalcNextDifficultyTarget(lastNode, HeaderVersion0, fakeParams)
 		require.NoErrorf(err, "Block index: %d", ii)
-		nodes = append(nodes, NewBlockNode(
+		nodes = append(nodes, NewPoWBlockNode(
 			lastNode,
 			nil,
 			uint32(ii),

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -403,11 +403,12 @@ type MigrationHeight struct {
 }
 
 const (
-	DefaultMigration                     MigrationName = "DefaultMigration"
-	UnlimitedDerivedKeysMigration        MigrationName = "UnlimitedDerivedKeysMigration"
-	AssociationsAndAccessGroupsMigration MigrationName = "AssociationsAndAccessGroupsMigration"
-	BalanceModelMigration                MigrationName = "BalanceModelMigration"
-	ProofOfStake1StateSetupMigration     MigrationName = "ProofOfStake1StateSetupMigration"
+	DefaultMigration                       MigrationName = "DefaultMigration"
+	UnlimitedDerivedKeysMigration          MigrationName = "UnlimitedDerivedKeysMigration"
+	AssociationsAndAccessGroupsMigration   MigrationName = "AssociationsAndAccessGroupsMigration"
+	BalanceModelMigration                  MigrationName = "BalanceModelMigration"
+	ProofOfStake1StateSetupMigration       MigrationName = "ProofOfStake1StateSetupMigration"
+	ProofOfStake2ConsensusCutoverMigration MigrationName = "ProofOfStake2ConsensusCutoverMigration"
 )
 
 type EncoderMigrationHeights struct {
@@ -424,6 +425,9 @@ type EncoderMigrationHeights struct {
 
 	// This coincides with the ProofOfStake1StateSetupBlockHeight
 	ProofOfStake1StateSetupMigration MigrationHeight
+
+	// This coincides with the ProofOfStake2ConsensusCutoverBlockHeight
+	ProofOfStake2ConsensusCutoverMigration MigrationHeight
 }
 
 func GetEncoderMigrationHeights(forkHeights *ForkHeights) *EncoderMigrationHeights {
@@ -452,6 +456,11 @@ func GetEncoderMigrationHeights(forkHeights *ForkHeights) *EncoderMigrationHeigh
 			Version: 4,
 			Height:  uint64(forkHeights.ProofOfStake1StateSetupBlockHeight),
 			Name:    ProofOfStake1StateSetupMigration,
+		},
+		ProofOfStake2ConsensusCutoverMigration: MigrationHeight{
+			Version: 5,
+			Height:  uint64(forkHeights.ProofOfStake2ConsensusCutoverBlockHeight),
+			Name:    ProofOfStake2ConsensusCutoverMigration,
 		},
 	}
 }

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -961,7 +961,7 @@ var DeSoMainnetParams = DeSoParams{
 	//   value should equal the amount of work it takes to get from whatever start node you
 	//   choose and the tip. This is done by running once, letting it fail, and then rerunning
 	//   with the value it outputs.
-	BitcoinStartBlockNode: NewBlockNode(
+	BitcoinStartBlockNode: NewPoWBlockNode(
 		nil,
 		mustDecodeHexBlockHashBitcoin("000000000000000000092d577cc673bede24b6d7199ee69c67eeb46c18fc978c"),
 		// Note the height is always one greater than the parent node.
@@ -1217,7 +1217,7 @@ var DeSoTestnetParams = DeSoParams{
 	DeSoNanosPurchasedAtGenesis:   uint64(6000000000000000),
 
 	// See comment in mainnet config.
-	BitcoinStartBlockNode: NewBlockNode(
+	BitcoinStartBlockNode: NewPoWBlockNode(
 		nil,
 		mustDecodeHexBlockHashBitcoin("000000000000003aae8fb976056413aa1d863eb5bee381ff16c9642283b1da1a"),
 		1897056,

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -425,9 +425,6 @@ type EncoderMigrationHeights struct {
 
 	// This coincides with the ProofOfStake1StateSetupBlockHeight
 	ProofOfStake1StateSetupMigration MigrationHeight
-
-	// This coincides with the ProofOfStake2ConsensusCutoverBlockHeight
-	ProofOfStake2ConsensusCutoverMigration MigrationHeight
 }
 
 func GetEncoderMigrationHeights(forkHeights *ForkHeights) *EncoderMigrationHeights {
@@ -456,11 +453,6 @@ func GetEncoderMigrationHeights(forkHeights *ForkHeights) *EncoderMigrationHeigh
 			Version: 4,
 			Height:  uint64(forkHeights.ProofOfStake1StateSetupBlockHeight),
 			Name:    ProofOfStake1StateSetupMigration,
-		},
-		ProofOfStake2ConsensusCutoverMigration: MigrationHeight{
-			Version: 5,
-			Height:  uint64(forkHeights.ProofOfStake2ConsensusCutoverBlockHeight),
-			Name:    ProofOfStake2ConsensusCutoverMigration,
 		},
 	}
 }

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -403,12 +403,11 @@ type MigrationHeight struct {
 }
 
 const (
-	DefaultMigration                       MigrationName = "DefaultMigration"
-	UnlimitedDerivedKeysMigration          MigrationName = "UnlimitedDerivedKeysMigration"
-	AssociationsAndAccessGroupsMigration   MigrationName = "AssociationsAndAccessGroupsMigration"
-	BalanceModelMigration                  MigrationName = "BalanceModelMigration"
-	ProofOfStake1StateSetupMigration       MigrationName = "ProofOfStake1StateSetupMigration"
-	ProofOfStake2ConsensusCutoverMigration MigrationName = "ProofOfStake2ConsensusCutoverMigration"
+	DefaultMigration                     MigrationName = "DefaultMigration"
+	UnlimitedDerivedKeysMigration        MigrationName = "UnlimitedDerivedKeysMigration"
+	AssociationsAndAccessGroupsMigration MigrationName = "AssociationsAndAccessGroupsMigration"
+	BalanceModelMigration                MigrationName = "BalanceModelMigration"
+	ProofOfStake1StateSetupMigration     MigrationName = "ProofOfStake1StateSetupMigration"
 )
 
 type EncoderMigrationHeights struct {

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -4707,7 +4707,7 @@ func SerializeBlockNode(blockNode *BlockNode) ([]byte, error) {
 }
 
 func DeserializeBlockNode(data []byte) (*BlockNode, error) {
-	blockNode := NewBlockNode(
+	blockNode := NewPoWBlockNode(
 		nil,          // Parent
 		&BlockHash{}, // Hash
 		0,            // Height
@@ -5116,7 +5116,7 @@ func InitDbWithDeSoGenesisBlock(params *DeSoParams, handle *badger.DB,
 	genesisBlock := params.GenesisBlock
 	diffTarget := MustDecodeHexBlockHash(params.MinDifficultyTargetHex)
 	blockHash := MustDecodeHexBlockHash(params.GenesisBlockHashHex)
-	genesisNode := NewBlockNode(
+	genesisNode := NewPoWBlockNode(
 		nil, // Parent
 		blockHash,
 		0, // Height

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -4670,7 +4670,7 @@ func DeleteUtxoOperationsForBlockWithTxn(txn *badger.Txn, snap *Snapshot, blockH
 	return DBDeleteWithTxn(txn, snap, _DbKeyForUtxoOps(blockHash))
 }
 
-func blockNodeProofOfStakeMigrationTriggered(height uint32) bool {
+func blockNodeProofOfStakeCutoverMigrationTriggered(height uint32) bool {
 	return height >= GlobalDeSoParams.ForkHeights.ProofOfStake2ConsensusCutoverBlockHeight
 }
 
@@ -4682,7 +4682,7 @@ func SerializeBlockNode(blockNode *BlockNode) ([]byte, error) {
 	}
 	data = append(data, blockNode.Hash[:]...)
 	data = append(data, UintToBuf(uint64(blockNode.Height))...)
-	if !blockNodeProofOfStakeMigrationTriggered(blockNode.Height) {
+	if !blockNodeProofOfStakeCutoverMigrationTriggered(blockNode.Height) {
 		// DifficultyTarget
 		if blockNode.DifficultyTarget == nil {
 			return nil, fmt.Errorf("SerializeBlockNode: DifficultyTarget cannot be nil")
@@ -4700,7 +4700,7 @@ func SerializeBlockNode(blockNode *BlockNode) ([]byte, error) {
 	data = append(data, serializedHeader...)
 
 	data = append(data, UintToBuf(uint64(blockNode.Status))...)
-	if blockNodeProofOfStakeMigrationTriggered(blockNode.Height) {
+	if blockNodeProofOfStakeCutoverMigrationTriggered(blockNode.Height) {
 		data = append(data, UintToBuf(uint64(blockNode.CommittedStatus))...)
 	}
 	return data, nil
@@ -4732,7 +4732,7 @@ func DeserializeBlockNode(data []byte) (*BlockNode, error) {
 	}
 	blockNode.Height = uint32(height)
 
-	if !blockNodeProofOfStakeMigrationTriggered(blockNode.Height) {
+	if !blockNodeProofOfStakeCutoverMigrationTriggered(blockNode.Height) {
 		// DifficultyTarget
 		_, err = io.ReadFull(rr, blockNode.DifficultyTarget[:])
 		if err != nil {
@@ -4775,7 +4775,7 @@ func DeserializeBlockNode(data []byte) (*BlockNode, error) {
 	blockNode.Status = BlockStatus(uint32(status))
 
 	// CommittedStatus
-	if blockNodeProofOfStakeMigrationTriggered(blockNode.Height) {
+	if blockNodeProofOfStakeCutoverMigrationTriggered(blockNode.Height) {
 		committedStatus, err := ReadUvarint(rr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "DeserializeBlockNode: Problem decoding CommittedStatus")

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -4701,7 +4701,7 @@ func (blockNode *BlockNode) serializeBlockNode(blockHeight uint64) ([]byte, erro
 	if !MigrationTriggered(blockHeight, ProofOfStake2ConsensusCutoverMigration) {
 		// DifficultyTarget
 		if blockNode.DifficultyTarget == nil {
-			return nil, fmt.Errorf("serializeBlockNode: DifficultyTarget cannot be nil"))
+			return nil, fmt.Errorf("serializeBlockNode: DifficultyTarget cannot be nil")
 		}
 		data = append(data, blockNode.DifficultyTarget[:]...)
 
@@ -4787,6 +4787,7 @@ func (blockNode *BlockNode) deserializeBlockNode(blockHeight uint64, rr *bytes.R
 		}
 		blockNode.CommittedStatus = CommittedBlockStatus(committedStatus)
 	}
+	return nil
 }
 
 func SerializeBlockNode(blockNode *BlockNode) ([]byte, error) {
@@ -4808,7 +4809,7 @@ func DeserializeBlockNode(data []byte) (*BlockNode, error) {
 
 	rr := bytes.NewReader(data)
 	// We use block height 0 to indicate that we should use the old serialization format.
-	err := blockNode.deserializeBlockNode( 0, rr)
+	err := blockNode.deserializeBlockNode(0, rr)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/db_utils.go
+++ b/lib/db_utils.go
@@ -4678,14 +4678,14 @@ func SerializeBlockNode(blockNode *BlockNode) ([]byte, error) {
 	data := []byte{}
 
 	if blockNode.Hash == nil {
-		return nil, fmt.Errorf("serializeBlockNode: Hash cannot be nil")
+		return nil, fmt.Errorf("SerializeBlockNode: Hash cannot be nil")
 	}
 	data = append(data, blockNode.Hash[:]...)
 	data = append(data, UintToBuf(uint64(blockNode.Height))...)
 	if !blockNodeProofOfStakeMigrationTriggered(blockNode.Height) {
 		// DifficultyTarget
 		if blockNode.DifficultyTarget == nil {
-			return nil, fmt.Errorf("serializeBlockNode: DifficultyTarget cannot be nil")
+			return nil, fmt.Errorf("SerializeBlockNode: DifficultyTarget cannot be nil")
 		}
 		data = append(data, blockNode.DifficultyTarget[:]...)
 

--- a/lib/postgres.go
+++ b/lib/postgres.go
@@ -4083,7 +4083,7 @@ func (postgres *Postgres) InitGenesisBlock(params *DeSoParams, db *badger.DB) er
 	genesisBlock := params.GenesisBlock
 	diffTarget := MustDecodeHexBlockHash(params.MinDifficultyTargetHex)
 	blockHash := MustDecodeHexBlockHash(params.GenesisBlockHashHex)
-	genesisNode := NewBlockNode(
+	genesisNode := NewPoWBlockNode(
 		nil,
 		blockHash,
 		0,


### PR DESCRIPTION
- Defines an enum for CommittedBlockStatus with two values, COMMITTED and UNCOMMITTED
- Adds CommittedStatus to BlockNode struct
- Renames NewBlockNode to NewPoWBlockNode, this function sets CommittedStatus to COMMITTED when called. The function signature does not change.
- Create NewPoSBlockNode function with the same parameters as NewPoWBlockNode PLUS CommittedStatus