### PR TITLE
Minor Cleanup for Encoder Test and Balance Model Height Setters

### DIFF
--- a/lib/block_view_access_group_members_test.go
+++ b/lib/block_view_access_group_members_test.go
@@ -51,10 +51,10 @@ func (data *accessGroupMembersTestData) GetInputType() transactionTestInputType 
 func TestBalanceModelAccessGroupMembers(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestAccessGroupMembersAdd(t)
-	TestAccessGroupMembersUpdate(t)
-	TestAccessGroupMembersRemove(t)
-	TestAccessGroupMembersTxnWithDerivedKey(t)
+	t.Run("TestAccessGroupMembersAdd", TestAccessGroupMembersAdd)
+	t.Run("TestAccessGroupMembersUpdate", TestAccessGroupMembersUpdate)
+	t.Run("TestAccessGroupMembersRemove", TestAccessGroupMembersRemove)
+	t.Run("TestAccessGroupMembersTxnWithDerivedKey", TestAccessGroupMembersTxnWithDerivedKey)
 }
 
 func TestAccessGroupMembersAdd(t *testing.T) {

--- a/lib/block_view_access_group_test.go
+++ b/lib/block_view_access_group_test.go
@@ -3,10 +3,11 @@ package lib
 import (
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type AccessGroupTestData struct {
@@ -35,7 +36,6 @@ func TestBalanceModelAccessGroups(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
 	TestAccessGroup(t)
-	TestAccessGroupTxnWithDerivedKey(t)
 }
 
 func TestAccessGroup(t *testing.T) {

--- a/lib/block_view_association_test.go
+++ b/lib/block_view_association_test.go
@@ -3,11 +3,12 @@ package lib
 import (
 	"bytes"
 	"errors"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/stretchr/testify/require"
 	"math"
 	"sort"
 	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBalanceModelAssociations(t *testing.T) {
@@ -19,9 +20,15 @@ func TestBalanceModelAssociations(t *testing.T) {
 func TestAssociations(t *testing.T) {
 	// Run all tests twice: once flushing all txns to the
 	// db, and once just keeping all txns in the mempool.
-	_testAssociations(t, true)
-	_testAssociations(t, false)
-	_testAssociationsWithDerivedKey(t)
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testAssociations(t, true)
+	})
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testAssociations(t, false)
+	})
+	t.Run("_testAssociationsWithDerivedKey", func(t *testing.T) {
+		_testAssociationsWithDerivedKey(t)
+	})
 }
 
 func _testAssociations(t *testing.T, flushToDB bool) {

--- a/lib/block_view_creator_coin_test.go
+++ b/lib/block_view_creator_coin_test.go
@@ -2,11 +2,12 @@ package lib
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
 )
 
 type _CreatorCoinTestData struct {
@@ -794,41 +795,41 @@ func _helpTestCreatorCoinBuySell(
 func TestBalanceModelCreatorCoins(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestCreatorCoinWithDiamonds(t)
-	TestCreatorCoinWithDiamondsFailureCases(t)
-	TestCreatorCoinDiamondAfterDeSoDiamondsBlockHeight(t)
-	TestCreatorCoinTransferSimple_CreatorCoinFounderReward(t)
-	TestCreatorCoinTransferSimple_DeSoFounderReward(t)
+	t.Run("TestCreatorCoinWithDiamonds", TestCreatorCoinWithDiamonds)
+	t.Run("TestCreatorCoinWithDiamondsFailureCases", TestCreatorCoinWithDiamondsFailureCases)
+	t.Run("TestCreatorCoinDiamondAfterDeSoDiamondsBlockHeight", TestCreatorCoinDiamondAfterDeSoDiamondsBlockHeight)
+	t.Run("TestCreatorCoinTransferSimple_CreatorCoinFounderReward", TestCreatorCoinTransferSimple_CreatorCoinFounderReward)
+	t.Run("TestCreatorCoinTransferSimple_DeSoFounderReward", TestCreatorCoinTransferSimple_DeSoFounderReward)
 }
 
 func TestBalanceModelCreatorCoins2(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestCreatorCoinTransferWithSwapIdentity(t)
-	TestCreatorCoinTransferWithSmallBalancesLeftOver(t)
-	TestCreatorCoinTransferWithMaxTransfers(t)
-	TestCreatorCoinTransferBelowMinThreshold(t)
-	TestCreatorCoinBuySellSimple_CreatorCoinFounderReward(t)
+	t.Run("TestCreatorCoinTransferWithSwapIdentity", TestCreatorCoinTransferWithSwapIdentity)
+	t.Run("TestCreatorCoinTransferWithSmallBalancesLeftOver", TestCreatorCoinTransferWithSmallBalancesLeftOver)
+	t.Run("TestCreatorCoinTransferWithMaxTransfers", TestCreatorCoinTransferWithMaxTransfers)
+	t.Run("TestCreatorCoinTransferBelowMinThreshold", TestCreatorCoinTransferBelowMinThreshold)
+	t.Run("TestCreatorCoinBuySellSimple_CreatorCoinFounderReward", TestCreatorCoinBuySellSimple_CreatorCoinFounderReward)
 }
 
 func TestBalanceModelCreatorCoins3(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestCreatorCoinBuySellSimple_DeSoFounderReward(t)
-	TestCreatorCoinSelfBuying_DeSoAndCreatorCoinFounderReward(t)
-	TestCreatorCoinTinyFounderRewardBuySellAmounts_CreatorCoinFounderReward(t)
-	TestCreatorCoinTinyFounderRewardBuySellAmounts_DeSoFounderReward(t)
-	TestCreatorCoinFullFounderRewardBuySellAmounts_CreatorCoinFounderReward(t)
+	t.Run("TestCreatorCoinBuySellSimple_DeSoFounderReward", TestCreatorCoinBuySellSimple_DeSoFounderReward)
+	t.Run("TestCreatorCoinSelfBuying_DeSoAndCreatorCoinFounderReward", TestCreatorCoinSelfBuying_DeSoAndCreatorCoinFounderReward)
+	t.Run("TestCreatorCoinTinyFounderRewardBuySellAmounts_CreatorCoinFounderReward", TestCreatorCoinTinyFounderRewardBuySellAmounts_CreatorCoinFounderReward)
+	t.Run("TestCreatorCoinTinyFounderRewardBuySellAmounts_DeSoFounderReward", TestCreatorCoinTinyFounderRewardBuySellAmounts_DeSoFounderReward)
+	t.Run("TestCreatorCoinFullFounderRewardBuySellAmounts_CreatorCoinFounderReward", TestCreatorCoinFullFounderRewardBuySellAmounts_CreatorCoinFounderReward)
 }
 
 func TestBalanceModelCreatorCoins4(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestCreatorCoinLargeFounderRewardBuySellAmounts(t)
-	TestCreatorCoinAroundThresholdBuySellAmounts(t)
-	TestSalomonSequence(t)
-	TestCreatorCoinBigBuyAfterSmallBuy(t)
-	TestCreatorCoinBigBigBuyBigSell(t)
+	t.Run("TestCreatorCoinLargeFounderRewardBuySellAmounts", TestCreatorCoinLargeFounderRewardBuySellAmounts)
+	t.Run("TestCreatorCoinAroundThresholdBuySellAmounts", TestCreatorCoinAroundThresholdBuySellAmounts)
+	t.Run("TestSalomonSequence", TestSalomonSequence)
+	t.Run("TestCreatorCoinBigBuyAfterSmallBuy", TestCreatorCoinBigBuyAfterSmallBuy)
+	t.Run("TestCreatorCoinBigBigBuyBigSell", TestCreatorCoinBigBigBuyBigSell)
 }
 
 func TestCreatorCoinWithDiamonds(t *testing.T) {

--- a/lib/block_view_dao_coin_limit_order_test.go
+++ b/lib/block_view_dao_coin_limit_order_test.go
@@ -3,21 +3,22 @@ package lib
 import (
 	"bytes"
 	"fmt"
-	"github.com/dgraph-io/badger/v3"
-	"github.com/holiman/uint256"
-	"github.com/stretchr/testify/require"
 	"math"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBalanceModelDAOCoinLimitOrders(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestZeroCostOrderEdgeCaseDAOCoinLimitOrder(t)
-	TestDAOCoinLimitOrder(t)
-	TestFlushingDAOCoinLimitOrders(t)
+	t.Run("TestZeroCostOrderEdgeCaseDAOCoinLimitOrder", TestZeroCostOrderEdgeCaseDAOCoinLimitOrder)
+	t.Run("TestDAOCoinLimitOrder", TestDAOCoinLimitOrder)
+	t.Run("TestFlushingDAOCoinLimitOrders", TestFlushingDAOCoinLimitOrders)
 }
 func TestZeroCostOrderEdgeCaseDAOCoinLimitOrder(t *testing.T) {
 	// -----------------------

--- a/lib/block_view_derived_key_test.go
+++ b/lib/block_view_derived_key_test.go
@@ -5,14 +5,15 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/dgraph-io/badger/v3"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math/rand"
-	"testing"
-	"time"
 )
 
 const (
@@ -871,13 +872,15 @@ func _doAuthorizeTxnWithExtraDataAndSpendingLimits(testMeta *TestMeta, utxoView 
 func TestBalanceModelAuthorizeDerivedKey(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestAuthorizeDerivedKeyBasic(t)
-	TestAuthorizeDerivedKeyBasicWithTransactionLimits(t)
-	TestAuthorizedDerivedKeyWithTransactionLimitsHardcore(t)
-	// We need to set the block height here to 7 so that encoder migrations have the proper version and heights.
-	// Otherwise, the access groups and associations migrations do not run when encoding Utxo Operations.
-	DeSoTestnetParams.ForkHeights.BalanceModelBlockHeight = 7
-	TestAuthorizeDerivedKeyWithTransactionSpendingLimitsAccessGroups(t)
+	t.Run("TestAuthorizeDerivedKeyBasic", TestAuthorizeDerivedKeyBasic)
+	t.Run("TestAuthorizeDerivedKeyBasicWithTransactionLimits", TestAuthorizeDerivedKeyBasicWithTransactionLimits)
+	t.Run("TestAuthorizedDerivedKeyWithTransactionLimitsHardcore", TestAuthorizedDerivedKeyWithTransactionLimitsHardcore)
+	t.Run("TestAuthorizeDerivedKeyWithTransactionSpendingLimitsAccessGroups", func(t *testing.T) {
+		// We need to set the block height here to 7 so that encoder migrations have the proper version and heights.
+		// Otherwise, the access groups and associations migrations do not run when encoding Utxo Operations.
+		DeSoTestnetParams.ForkHeights.BalanceModelBlockHeight = 7
+		TestAuthorizeDerivedKeyWithTransactionSpendingLimitsAccessGroups(t)
+	})
 }
 
 func TestAuthorizeDerivedKeyBasic(t *testing.T) {

--- a/lib/block_view_message_test.go
+++ b/lib/block_view_message_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/dgraph-io/badger/v3"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/dgraph-io/badger/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBasePointSignature(t *testing.T) {
@@ -116,9 +117,9 @@ func _privateMessageWithExtraData(t *testing.T, chain *Blockchain, db *badger.DB
 func TestBalanceModelPrivateMessages(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestPrivateMessages(t)
-	TestMessagingKeys(t)
-	TestGroupMessages(t)
+	t.Run("TestPrivateMessages", TestPrivateMessages)
+	t.Run("TestMessagingKeys", TestMessagingKeys)
+	t.Run("TestGroupMessages", TestGroupMessages)
 }
 
 func TestPrivateMessage(t *testing.T) {

--- a/lib/block_view_nft_test.go
+++ b/lib/block_view_nft_test.go
@@ -1,13 +1,14 @@
 package lib
 
 import (
-	"github.com/dgraph-io/badger/v3"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"math"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func _createNFTWithAdditionalRoyalties(t *testing.T, chain *Blockchain, db *badger.DB, params *DeSoParams,
@@ -831,32 +832,32 @@ func _burnNFTWithTestMeta(
 func TestBalanceModelNFTs(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestNFTBasic(t)
-	TestNFTRoyaltiesAndSpendingOfBidderUTXOs(t)
-	TestNFTSerialNumberZeroBid(t)
-	TestNFTMinimumBidAmount(t)
-	TestNFTCreatedIsNotForSale(t)
+	t.Run("TestNFTBasic", TestNFTBasic)
+	t.Run("TestNFTRoyaltiesAndSpendingOfBidderUTXOs", TestNFTRoyaltiesAndSpendingOfBidderUTXOs)
+	t.Run("TestNFTSerialNumberZeroBid", TestNFTSerialNumberZeroBid)
+	t.Run("TestNFTMinimumBidAmount", TestNFTMinimumBidAmount)
+	t.Run("TestNFTCreatedIsNotForSale", TestNFTCreatedIsNotForSale)
 }
 
 // Break up into multiple tests to keep memory footprint lower
 func TestBalanceModelNFTs2(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestNFTMoreErrorCases(t)
-	TestNFTBidsAreCanceledAfterAccept(t)
-	TestNFTDifferentMinBidAmountSerialNumbers(t)
-	TestNFTMaxCopiesGlobalParam(t)
-	TestNFTPreviousOwnersCantAcceptBids(t)
+	t.Run("TestNFTMoreErrorCases", TestNFTMoreErrorCases)
+	t.Run("TestNFTBidsAreCanceledAfterAccept", TestNFTBidsAreCanceledAfterAccept)
+	t.Run("TestNFTDifferentMinBidAmountSerialNumbers", TestNFTDifferentMinBidAmountSerialNumbers)
+	t.Run("TestNFTMaxCopiesGlobalParam", TestNFTMaxCopiesGlobalParam)
+	t.Run("TestNFTPreviousOwnersCantAcceptBids", TestNFTPreviousOwnersCantAcceptBids)
 }
 
 func TestBalanceModelNFTs3(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestNFTTransfersAndBurns(t)
-	TestBidAmountZero(t)
-	TestNFTBuyNow(t)
-	TestNFTSplits(t)
-	TestNFTSplitsHardcorePKIDBug(t)
+	t.Run("TestNFTTransfersAndBurns", TestNFTTransfersAndBurns)
+	t.Run("TestBidAmountZero", TestBidAmountZero)
+	t.Run("TestNFTBuyNow", TestNFTBuyNow)
+	t.Run("TestNFTSplits", TestNFTSplits)
+	t.Run("TestNFTSplitsHardcorePKIDBug", TestNFTSplitsHardcorePKIDBug)
 }
 
 func TestNFTBasic(t *testing.T) {

--- a/lib/block_view_post_test.go
+++ b/lib/block_view_post_test.go
@@ -2106,6 +2106,12 @@ func TestDeSoDiamondErrorCases(t *testing.T) {
 }
 
 func TestFreezingPosts(t *testing.T) {
+	// Set up block heights
+	DeSoTestnetParams.ForkHeights.AssociationsAndAccessGroupsBlockHeight = 1
+	DeSoTestnetParams.EncoderMigrationHeights = GetEncoderMigrationHeights(&DeSoTestnetParams.ForkHeights)
+	DeSoTestnetParams.EncoderMigrationHeightsList = GetEncoderMigrationHeightsList(&DeSoTestnetParams.ForkHeights)
+	GlobalDeSoParams = DeSoTestnetParams
+
 	// Initialize blockchain.
 	chain, params, db := NewLowDifficultyBlockchain(t)
 	defer func() {
@@ -2113,10 +2119,7 @@ func TestFreezingPosts(t *testing.T) {
 			require.NoError(t, ResetPostgres(chain.postgres))
 		}
 	}()
-	params.ForkHeights.AssociationsAndAccessGroupsBlockHeight = 1
-	params.EncoderMigrationHeights = GetEncoderMigrationHeights(&params.ForkHeights)
-	params.EncoderMigrationHeightsList = GetEncoderMigrationHeightsList(&params.ForkHeights)
-	GlobalDeSoParams = *params
+
 	mempool, miner := NewTestMiner(t, chain, params, true)
 
 	// Mine a few blocks to give the senderPkString some money.

--- a/lib/block_view_post_test.go
+++ b/lib/block_view_post_test.go
@@ -4,14 +4,15 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/dgraph-io/badger/v3"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func _submitPost(t *testing.T, chain *Blockchain, db *badger.DB,
@@ -294,10 +295,10 @@ func _doSubmitPostTxn(t *testing.T, chain *Blockchain, db *badger.DB,
 func TestBalanceModelSubmitPost(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestSubmitPost(t)
-	TestDeSoDiamonds(t)
-	TestDeSoDiamondErrorCases(t)
-	TestFreezingPosts(t)
+	t.Run("TestSubmitPost", TestSubmitPost)
+	t.Run("TestDeSoDiamonds", TestDeSoDiamonds)
+	t.Run("TestDeSoDiamondErrorCases", TestDeSoDiamondErrorCases)
+	t.Run("TestFreezingPosts", TestFreezingPosts)
 }
 
 func TestSubmitPost(t *testing.T) {

--- a/lib/block_view_profile_test.go
+++ b/lib/block_view_profile_test.go
@@ -220,19 +220,19 @@ const (
 func TestBalanceModelUpdateProfile(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestUpdateProfile(t)
-	TestSpamUpdateProfile(t)
-	TestUpdateProfileChangeBack(t)
+	t.Run("TestUpdateProfile", TestUpdateProfile)
+	t.Run("TestSpamUpdateProfile", TestSpamUpdateProfile)
+	t.Run("TestUpdateProfileChangeBack", TestUpdateProfileChangeBack)
 }
 
 func TestBalanceModelSwapIdentity(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestSwapIdentityNOOPCreatorCoinBuySimple(t)
-	TestSwapIdentityCreatorCoinBuySimple(t)
-	TestSwapIdentityFailureCases(t)
-	TestSwapIdentityMain(t)
-	TestSwapIdentityWithFollows(t)
+	t.Run("TestSwapIdentityNOOPCreatorCoinBuySimple", TestSwapIdentityNOOPCreatorCoinBuySimple)
+	t.Run("TestSwapIdentityCreatorCoinBuySimple", TestSwapIdentityCreatorCoinBuySimple)
+	t.Run("TestSwapIdentityFailureCases", TestSwapIdentityFailureCases)
+	t.Run("TestSwapIdentityMain", TestSwapIdentityMain)
+	t.Run("TestSwapIdentityWithFollows", TestSwapIdentityWithFollows)
 }
 
 func TestUpdateProfile(t *testing.T) {

--- a/lib/block_view_stake_test.go
+++ b/lib/block_view_stake_test.go
@@ -14,16 +14,20 @@ import (
 )
 
 func TestStaking(t *testing.T) {
-	_testStaking(t, false)
-	_testStaking(t, true)
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testStaking(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testStaking(t, true)
+	})
 }
 
 func _testStaking(t *testing.T, flushToDB bool) {
 	// Local variables
 	var err error
-
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
 
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)
@@ -1670,14 +1674,18 @@ func TestStakingWithDerivedKey(t *testing.T) {
 }
 
 func TestGetTopStakesByStakeAmount(t *testing.T) {
-	_testGetTopStakesByStakeAmount(t, false)
-	_testGetTopStakesByStakeAmount(t, true)
-}
-
-func _testGetTopStakesByStakeAmount(t *testing.T, flushToDB bool) {
 	// Initialize balance model fork heights.
 	setBalanceModelBlockHeights(t)
 
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testGetTopStakesByStakeAmount(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testGetTopStakesByStakeAmount(t, true)
+	})
+}
+
+func _testGetTopStakesByStakeAmount(t *testing.T, flushToDB bool) {
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)
 	mempool, miner := NewTestMiner(t, chain, params, true)
@@ -2107,15 +2115,19 @@ func TestStakeLockupEpochDuration(t *testing.T) {
 }
 
 func TestStakingToJailedValidator(t *testing.T) {
-	testStakingToJailedValidator(t, false)
-	testStakingToJailedValidator(t, true)
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
+	t.Run("flushToDB=false", func(t *testing.T) {
+		testStakingToJailedValidator(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		testStakingToJailedValidator(t, true)
+	})
 }
 
 func testStakingToJailedValidator(t *testing.T, flushToDB bool) {
 	var err error
-
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
 
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)

--- a/lib/block_view_test.go
+++ b/lib/block_view_test.go
@@ -1747,20 +1747,23 @@ func TestBasicTransferSignatures(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	chain, params, db := NewLowDifficultyBlockchain(t)
-	postgres := chain.postgres
-	params.ForkHeights.NFTTransferOrBurnAndDerivedKeysBlockHeight = uint32(0)
-	params.ForkHeights.DerivedKeySetSpendingLimitsBlockHeight = uint32(0)
-	params.ForkHeights.DerivedKeyTrackSpendingLimitsBlockHeight = uint32(0)
-	// Make sure encoder migrations are not triggered yet.
-	GlobalDeSoParams = *params
-	GlobalDeSoParams.ForkHeights.DeSoUnlimitedDerivedKeysBlockHeight = uint32(100)
-	for ii := range GlobalDeSoParams.EncoderMigrationHeightsList {
-		if GlobalDeSoParams.EncoderMigrationHeightsList[ii].Version == 0 {
+	// Set up block heights
+	DeSoTestnetParams.ForkHeights.NFTTransferOrBurnAndDerivedKeysBlockHeight = uint32(0)
+	DeSoTestnetParams.ForkHeights.DerivedKeySetSpendingLimitsBlockHeight = uint32(0)
+	DeSoTestnetParams.ForkHeights.DerivedKeyTrackSpendingLimitsBlockHeight = uint32(0)
+	DeSoTestnetParams.ForkHeights.DeSoUnlimitedDerivedKeysBlockHeight = uint32(100)
+	for ii := range DeSoTestnetParams.EncoderMigrationHeightsList {
+		if DeSoTestnetParams.EncoderMigrationHeightsList[ii].Version == 0 {
 			continue
 		}
-		GlobalDeSoParams.EncoderMigrationHeightsList[ii].Height = 100
+		DeSoTestnetParams.EncoderMigrationHeightsList[ii].Height = 100
 	}
+
+	// Make sure encoder migrations are not triggered yet.
+	GlobalDeSoParams = DeSoTestnetParams
+
+	chain, params, db := NewLowDifficultyBlockchain(t)
+	postgres := chain.postgres
 
 	_ = db
 	mempool, miner := NewTestMiner(t, chain, params, true /*isSender*/)

--- a/lib/block_view_test.go
+++ b/lib/block_view_test.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	_ "net/http/pprof"
+	"reflect"
+	"sort"
+	"testing"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/decred/dcrd/lru"
 	"github.com/dgraph-io/badger/v3"
@@ -11,10 +16,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	_ "net/http/pprof"
-	"reflect"
-	"sort"
-	"testing"
 )
 
 func _strToPk(t *testing.T, pkStr string) []byte {
@@ -82,13 +83,13 @@ func setBalanceModelBlockHeights(t *testing.T) {
 }
 
 func resetBalanceModelBlockHeights() {
-	DeSoTestnetParams.ForkHeights.NFTTransferOrBurnAndDerivedKeysBlockHeight = 1000000
-	DeSoTestnetParams.ForkHeights.DerivedKeySetSpendingLimitsBlockHeight = 1000000
-	DeSoTestnetParams.ForkHeights.DerivedKeyTrackSpendingLimitsBlockHeight = 1000000
-	DeSoTestnetParams.ForkHeights.DerivedKeyEthSignatureCompatibilityBlockHeight = 1000000
-	DeSoTestnetParams.ForkHeights.ExtraDataOnEntriesBlockHeight = 1000000
-	DeSoTestnetParams.ForkHeights.AssociationsAndAccessGroupsBlockHeight = 1000000
-	DeSoTestnetParams.ForkHeights.BalanceModelBlockHeight = 1000000
+	DeSoTestnetParams.ForkHeights.NFTTransferOrBurnAndDerivedKeysBlockHeight = uint32(60743)
+	DeSoTestnetParams.ForkHeights.DerivedKeySetSpendingLimitsBlockHeight = uint32(304087)
+	DeSoTestnetParams.ForkHeights.DerivedKeyTrackSpendingLimitsBlockHeight = uint32(304087 + 18*60)
+	DeSoTestnetParams.ForkHeights.DerivedKeyEthSignatureCompatibilityBlockHeight = uint32(360584)
+	DeSoTestnetParams.ForkHeights.ExtraDataOnEntriesBlockHeight = uint32(304087)
+	DeSoTestnetParams.ForkHeights.AssociationsAndAccessGroupsBlockHeight = uint32(596555)
+	DeSoTestnetParams.ForkHeights.BalanceModelBlockHeight = uint32(683058)
 	DeSoTestnetParams.EncoderMigrationHeights = GetEncoderMigrationHeights(&DeSoTestnetParams.ForkHeights)
 	DeSoTestnetParams.EncoderMigrationHeightsList = GetEncoderMigrationHeightsList(&DeSoTestnetParams.ForkHeights)
 	GlobalDeSoParams = DeSoTestnetParams
@@ -303,16 +304,16 @@ func (tes *transactionTestSuite) Run() {
 	}
 }
 
-const TestDeSoEncoderRetries = 3
+const testDeSoEncoderRetries = 3
 
-func TestDeSoEncoderSetup(t *testing.T) {
+func setupTestDeSoEncoder(t *testing.T) {
 	EncodeToBytesImpl = func(blockHeight uint64, encoder DeSoEncoder, skipMetadata ...bool) []byte {
 		versionByte := encoder.GetVersionByte(blockHeight)
 		encodingBytes := encodeToBytes(blockHeight, encoder, skipMetadata...)
 		// Check for deterministic encoding, try re-encoding the same encoder a couple of times and compare it with
 		// the original bytes.
 		{
-			for ii := 0; ii < TestDeSoEncoderRetries; ii++ {
+			for ii := 0; ii < testDeSoEncoderRetries; ii++ {
 				newVersionByte := encoder.GetVersionByte(blockHeight)
 				reEncodingBytes := encodeToBytes(blockHeight, encoder, skipMetadata...)
 				if !bytes.Equal(encodingBytes, reEncodingBytes) {
@@ -329,7 +330,7 @@ func TestDeSoEncoderSetup(t *testing.T) {
 	}
 }
 
-func TestDeSoEncoderShutdown(t *testing.T) {
+func resetTestDeSoEncoder(t *testing.T) {
 	EncodeToBytesImpl = encodeToBytes
 }
 
@@ -1464,9 +1465,9 @@ func TestUpdateGlobalParams(t *testing.T) {
 func TestBalanceModelBasicTransfers(t *testing.T) {
 	setBalanceModelBlockHeights(t)
 
-	TestBasicTransfer(t)
-	TestBasicTransferSignatures(t)
-	TestBlockRewardPatch(t)
+	t.Run("TestBasicTransfer", TestBasicTransfer)
+	t.Run("TestBasicTransferSignatures", TestBasicTransferSignatures)
+	t.Run("TestBlockRewardPatch", TestBlockRewardPatch)
 }
 
 func TestBasicTransfer(t *testing.T) {

--- a/lib/block_view_validator_test.go
+++ b/lib/block_view_validator_test.go
@@ -15,8 +15,15 @@ import (
 )
 
 func TestValidatorRegistration(t *testing.T) {
-	_testValidatorRegistration(t, false)
-	_testValidatorRegistration(t, true)
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testValidatorRegistration(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testValidatorRegistration(t, true)
+	})
 }
 
 func _testValidatorRegistration(t *testing.T, flushToDB bool) {
@@ -25,9 +32,6 @@ func _testValidatorRegistration(t *testing.T, flushToDB bool) {
 	var validatorEntry *ValidatorEntry
 	var validatorEntries []*ValidatorEntry
 	var err error
-
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
 
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)
@@ -676,16 +680,20 @@ func TestValidatorRegistrationWithDerivedKey(t *testing.T) {
 }
 
 func TestGetTopActiveValidatorsByStakeAmount(t *testing.T) {
-	_testGetTopActiveValidatorsByStakeAmount(t, false)
-	_testGetTopActiveValidatorsByStakeAmount(t, true)
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testGetTopActiveValidatorsByStakeAmount(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testGetTopActiveValidatorsByStakeAmount(t, true)
+	})
 }
 
 func _testGetTopActiveValidatorsByStakeAmount(t *testing.T, flushToDB bool) {
 	var validatorEntries []*ValidatorEntry
 	var err error
-
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
 
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)
@@ -1107,17 +1115,21 @@ func TestGetTopActiveValidatorsByStakeMergingDbAndUtxoView(t *testing.T) {
 }
 
 func TestUpdatingValidatorDisableDelegatedStake(t *testing.T) {
-	_testUpdatingValidatorDisableDelegatedStake(t, false)
-	_testUpdatingValidatorDisableDelegatedStake(t, true)
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testUpdatingValidatorDisableDelegatedStake(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testUpdatingValidatorDisableDelegatedStake(t, true)
+	})
 }
 
 func _testUpdatingValidatorDisableDelegatedStake(t *testing.T, flushToDB bool) {
 	var validatorEntry *ValidatorEntry
 	var stakeEntries []*StakeEntry
 	var err error
-
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
 
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)
@@ -1288,8 +1300,15 @@ func _testUpdatingValidatorDisableDelegatedStake(t *testing.T, flushToDB bool) {
 }
 
 func TestUnregisterAsValidator(t *testing.T) {
-	_testUnregisterAsValidator(t, false)
-	_testUnregisterAsValidator(t, true)
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testUnregisterAsValidator(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testUnregisterAsValidator(t, true)
+	})
 }
 
 func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
@@ -1298,9 +1317,6 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 	var lockedStakeEntry *LockedStakeEntry
 	_ = lockedStakeEntry
 	var err error
-
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
 
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)
@@ -1465,16 +1481,20 @@ func _testUnregisterAsValidator(t *testing.T, flushToDB bool) {
 }
 
 func TestUnjailValidator(t *testing.T) {
-	_testUnjailValidator(t, false)
-	_testUnjailValidator(t, true)
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
+	t.Run("flushToDB=false", func(t *testing.T) {
+		_testUnjailValidator(t, false)
+	})
+	t.Run("flushToDB=true", func(t *testing.T) {
+		_testUnjailValidator(t, true)
+	})
 }
 
 func _testUnjailValidator(t *testing.T, flushToDB bool) {
 	var validatorEntry *ValidatorEntry
 	var err error
-
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
 
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)

--- a/lib/pos_epoch_complete_hook_test.go
+++ b/lib/pos_epoch_complete_hook_test.go
@@ -54,6 +54,9 @@ func TestIsLastBlockInCurrentEpoch(t *testing.T) {
 }
 
 func TestRunEpochCompleteHook(t *testing.T) {
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
 	// Initialize test chain, miner, and testMeta
 	testMeta := _setUpMinerAndTestMetaForEpochCompleteTest(t)
 
@@ -476,6 +479,9 @@ func TestRunEpochCompleteHook(t *testing.T) {
 }
 
 func TestStakingRewardDistribution(t *testing.T) {
+	// Initialize balance model fork heights.
+	setBalanceModelBlockHeights(t)
+
 	// Initialize test chain, miner, and testMeta
 	testMeta := _setUpMinerAndTestMetaForEpochCompleteTest(t)
 
@@ -741,9 +747,6 @@ func TestStakingRewardDistribution(t *testing.T) {
 }
 
 func _setUpMinerAndTestMetaForEpochCompleteTest(t *testing.T) *TestMeta {
-	// Initialize balance model fork heights.
-	setBalanceModelBlockHeights(t)
-
 	// Initialize test chain and miner.
 	chain, params, db := NewLowDifficultyBlockchain(t)
 	mempool, miner := NewTestMiner(t, chain, params, true)

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -30,4 +30,4 @@ RUN ./scripts/install-relic.sh
 # build backend
 RUN GOOS=linux go build -mod=mod -a -installsuffix cgo -o bin/core main.go
 
-ENTRYPOINT ["go", "test", "-tags", "relic", "-v", "github.com/deso-protocol/core/bls", "github.com/deso-protocol/core/collections", "github.com/deso-protocol/core/consensus", "github.com/deso-protocol/core/lib"]
+ENTRYPOINT ["go", "test", "-tags", "relic", "-v", "-failfast", "-p", "1", "github.com/deso-protocol/core/bls", "github.com/deso-protocol/core/collections", "github.com/deso-protocol/core/consensus", "github.com/deso-protocol/core/lib"]


### PR DESCRIPTION
There's an interplay between between the encoder determinism testing and unit tests that set the balance model heights. This PR cleans up 4 things:
- for nested tests, it runs the the inner tests as sub-tests so that their cleanups are run immediately after the subtest completes
- it updates the test encoder setup to a unit function instead of a unit test in itself. This prevents the original setup and shutdown from being run when not needed
- it removes duplicate calls to setBalanceModelBlockHeights within the same test, so that fewer t.Cleanups are scheduled for it
- when cleaning up DeSoMiner and DeSoBlockProducer, it adds a time.Sleep after the two instances been stopped to avoid race conditions

The above don't eliminate the race conditions in CI, but reduce the chances significantly enough point that they're no longer disruptive