### PR TITLE
Add E2E Integration Test With Multiple Consensus Nodes

### DIFF
--- a/consensus/integration_test.go
+++ b/consensus/integration_test.go
@@ -1,0 +1,247 @@
+package consensus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/deso-protocol/core/collections"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// This integration test simulates a network of 4 nodes with equal stake. It tests the
+// a scenario in which a super-majority of stake is always online. Nodes sporadically
+// go offline and come back online. The network should continue to produce blocks
+// as long as a super-majority of stake is online.
+func TestNetworkWithOfflineValidators(t *testing.T) {
+	// Create 4 nodes with equal stake. The network has super-majority of stake online
+	// as long as 3 out of 4 nodes are online.
+	node1 := newValidatorNode(uint256.NewInt().SetUint64(50), true)  // block proposer
+	node2 := newValidatorNode(uint256.NewInt().SetUint64(50), false) // validator
+	node3 := newValidatorNode(uint256.NewInt().SetUint64(50), false) // validator
+	node4 := newValidatorNode(uint256.NewInt().SetUint64(50), false) // validator
+
+	allNodes := []*validatorNode{node1, node2, node3, node4}
+
+	// Create the genesis block signed by all four nodes.
+	genesisBlock := createDummyBlockWithVoteQC(createDummyBlockHash(), 2, 2, allNodes)
+
+	// Set the crank and timeout durations
+	crankTimer := time.Millisecond * 100    // Produce a block every 100ms
+	timeoutTimer := time.Millisecond * 1000 // Time out if there is no block broadcast within 1000ms
+
+	// Initialize all nodes and and connect them to each other
+	for _, validator := range allNodes {
+		require.NoError(t, validator.Init(crankTimer, timeoutTimer, genesisBlock, allNodes))
+	}
+
+	// Start all nodes' consensus event loops.
+	for _, node := range allNodes {
+		node.Start()
+	}
+
+	// Broadcast a block with a valid QC to all nodes. This kicks off the steady state flow
+	// of the Fast-HotStuff consensus. All nodes will begin voting starting from this block.
+	initialBlockToBroadcast := createDummyBlockWithVoteQC(genesisBlock.GetBlockHash(), 3, 3, allNodes)
+	for _, node := range allNodes {
+		node.ProcessBlock(initialBlockToBroadcast)
+	}
+
+	// Let all nodes run for 0.5 seconds so that the network produces at least one block.
+	time.Sleep(time.Millisecond * 500)
+
+	// Stop node 2 to simulate it going offline. The network has enough stake online
+	// to continue producing blocks.
+	node2.Stop()
+
+	// Let all nodes run for 0.5 seconds so that the network produces at least one block.
+	time.Sleep(time.Millisecond * 500)
+
+	// Restart node 2 to simulate it going back online, and stop node 3 to simulate it
+	// going offline. The network has enough stake online to continue producing blocks.
+	node2.Start()
+	node3.Stop()
+
+	// Let all nodes run for 0.5 seconds so that the network produces at least one block.
+	time.Sleep(time.Millisecond * 500)
+
+	// Restart node 3 to simulate it going back online, and stop node 4 to simulate it
+	// going offline. The network has enough stake online to continue producing blocks.
+	node3.Start()
+	node4.Stop()
+
+	// Let all nodes run for 0.5 seconds so that the network produces at least one block.
+	time.Sleep(time.Millisecond * 500)
+
+	// Stop all remaining nodes
+	node1.Stop()
+	node2.Stop()
+	node3.Stop()
+
+	// Validate the resulting chain of blocks stored by all nodes
+	validateAndPrintBlockChain(t, node1, node1.safeBlocks)
+	validateAndPrintBlockChain(t, node2, node2.safeBlocks)
+	validateAndPrintBlockChain(t, node3, node3.safeBlocks)
+	validateAndPrintBlockChain(t, node4, node4.safeBlocks)
+
+	// Verify that the network has produced more blocks after the node 4 stopped
+	require.Greater(t, node3.eventLoop.tip.block.GetView(), node4.eventLoop.tip.block.GetView())
+	require.Greater(t, node3.eventLoop.tip.block.GetHeight(), node4.eventLoop.tip.block.GetHeight())
+}
+
+// This integration test simulates a network of 4 nodes with equal stake. It tests the
+// a scenario in which a super-majority of stake is always online, but the block proposer
+// goes offline causing other nodes to timeout. The block proposer comes back online and
+// the network gracefully recovers.
+func TestNetworkWithOfflineBlockProposer(t *testing.T) {
+	// Create 4 nodes with equal stake. The network has super-majority of stake online
+	// as long as 3 out of 4 nodes are online.
+	node1 := newValidatorNode(uint256.NewInt().SetUint64(50), true)  // block proposer
+	node2 := newValidatorNode(uint256.NewInt().SetUint64(50), false) // validator
+	node3 := newValidatorNode(uint256.NewInt().SetUint64(50), false) // validator
+	node4 := newValidatorNode(uint256.NewInt().SetUint64(50), false) // validator
+
+	allNodes := []*validatorNode{node1, node2, node3, node4}
+
+	// Create the genesis block signed by all four nodes.
+	genesisBlock := createDummyBlockWithVoteQC(createDummyBlockHash(), 2, 2, allNodes)
+
+	// Set the crank and timeout durations
+	crankTimer := time.Millisecond * 500    // Produce a block every 500ms
+	timeoutTimer := time.Millisecond * 1000 // Time out if there is no block broadcast within 1000ms
+
+	// Initialize all nodes and and connect them to each other
+	for _, validator := range allNodes {
+		require.NoError(t, validator.Init(crankTimer, timeoutTimer, genesisBlock, allNodes))
+	}
+
+	// Start all nodes' consensus event loops.
+	for _, node := range allNodes {
+		node.Start()
+	}
+
+	// Broadcast a block with a valid QC to all nodes. This kicks off the steady state flow
+	// of the Fast-HotStuff consensus. All nodes will begin voting starting from this block.
+	initialBlockToBroadcast := createDummyBlockWithVoteQC(genesisBlock.GetBlockHash(), 3, 3, allNodes)
+	for _, node := range allNodes {
+		node.ProcessBlock(initialBlockToBroadcast)
+	}
+
+	// Let all nodes run for 1 second so that the network produces at least one block.
+	time.Sleep(time.Millisecond * 1000)
+
+	// Stop node 1 to simulate the block proposer going offline. All other validators will
+	// begin to time out. The network does not switch leaders during timeouts and instead
+	// waits for the block proposer to come back online.
+	node1.Stop()
+
+	// Cache node 1's tip during the network halt
+	node1TipDuringNetworkHalt := node1.eventLoop.tip.block.(*block)
+
+	// Let all online nodes run for 2 seconds so they time out at least once.
+	time.Sleep(time.Millisecond * 2000)
+
+	// Restart node 2 to simulate a block proposer coming online.
+	node1.Start()
+
+	// Let all nodes run for 10 seconds. The block proposer's view start off lower than the
+	// all other validators. All nodes' timeout have exponential backoff so they should all
+	// converge on the same view eventually.
+	time.Sleep(time.Millisecond * 10000)
+
+	// Stop remaining nodes
+	for _, node := range allNodes {
+		node.Stop()
+	}
+
+	// Validate the resulting chain of blocks stored by all nodes
+	validateAndPrintBlockChain(t, node1, node1.safeBlocks)
+	validateAndPrintBlockChain(t, node2, node2.safeBlocks)
+	validateAndPrintBlockChain(t, node3, node3.safeBlocks)
+	validateAndPrintBlockChain(t, node4, node4.safeBlocks)
+
+	// Verify that the network has produced at least one block since the block proposer returned
+	require.Greater(t, node3.eventLoop.tip.block.GetView(), node1TipDuringNetworkHalt.GetView())
+	require.Greater(t, node3.eventLoop.tip.block.GetHeight(), node1TipDuringNetworkHalt.GetHeight())
+}
+
+// This integration test simulates a network of 3 nodes, where a super-majority of stake is
+// concentrated on node. It tests the a scenario in which the super-majority of stake goes
+// offline, killing liveness. The network can recover as long as the super-majority of stake
+// can sync to the same starting block height once they come back online. It simulates recovery
+// from a catastrophic network failure.
+func TestNetworkRecoveryAfterCatastrophicFailure(t *testing.T) {
+	// Create 3 nodes with equal stake. Node 3 has a super-majority of the the stake
+	// and needs to stay online for the network to remain live.
+	node1 := newValidatorNode(uint256.NewInt().SetUint64(10), true)  // block proposer
+	node2 := newValidatorNode(uint256.NewInt().SetUint64(10), false) // validator
+	node3 := newValidatorNode(uint256.NewInt().SetUint64(80), false) // validator
+
+	allNodes := []*validatorNode{node1, node2, node3}
+
+	// Create the genesis block signed by all three nodes.
+	genesisBlock := createDummyBlockWithVoteQC(createDummyBlockHash(), 2, 2, allNodes)
+
+	// Set the crank and timeout durations
+	crankTimer := time.Millisecond * 500    // Produce a block every 500ms
+	timeoutTimer := time.Millisecond * 1000 // Time out if there is no block broadcast within 1000ms
+
+	// Initialize all nodes and and connect them to each other
+	for _, validator := range allNodes {
+		require.NoError(t, validator.Init(crankTimer, timeoutTimer, genesisBlock, allNodes))
+	}
+
+	// Start all nodes' consensus event loops.
+	for _, node := range allNodes {
+		node.Start()
+	}
+
+	// Broadcast a block with a valid QC to all nodes. This kicks off the steady state flow
+	// of the Fast-HotStuff consensus. All nodes will begin voting starting from this block.
+	initialBlockToBroadcast := createDummyBlockWithVoteQC(genesisBlock.GetBlockHash(), 3, 3, allNodes)
+	for _, node := range allNodes {
+		node.ProcessBlock(initialBlockToBroadcast)
+	}
+
+	// Let all nodes run for 1 second so that the network produces at least one block.
+	time.Sleep(time.Millisecond * 1000)
+
+	// Stop node 3 to simulate the network going down catastrophically. All nodes will begin to
+	// time out. No blocks will be proposed during this time.
+	node3.Stop()
+
+	// Let all online nodes run for 2 seconds so they time out at least once. The block proposer
+	// may proposer at most one block during this time if it had enough votes stored for its current
+	// tip to build a QC. The QC will not reach node 3.
+	//
+	// The network has halted during this period.
+	time.Sleep(time.Millisecond * 2000)
+
+	// Cache node 3's tip during the network halt. Nodes internal clocks and view will during this
+	// period.
+	node3TipDuringNetworkHalt := node3.eventLoop.tip.block.(*block)
+
+	// After a catastrophic network failure, nodes with a super-majority of stake need to somehow
+	// agree on a starting state of the chain. As long as they are able to sync from or to any peer
+	// that eventually becomes a block proposer, the network will recover.
+	node3.Resync(node1.eventLoop.tip.block.(*block), collections.MapValues(node1.safeBlocks))
+	node3.Start()
+
+	// Let all nodes run for 10 seconds. Eventually all nodes will converge on a single view and
+	// the network will start producing blocks again.
+	time.Sleep(time.Millisecond * 10000)
+
+	// Stop remaining nodes
+	for _, node := range allNodes {
+		node.Stop()
+	}
+
+	// Validate and print resulting chain of blocks stored by all nodes
+	validateAndPrintBlockChain(t, node1, node1.safeBlocks)
+	validateAndPrintBlockChain(t, node2, node2.safeBlocks)
+	validateAndPrintBlockChain(t, node3, node3.safeBlocks)
+
+	// Verify that the network has produced at least one block since it recovered
+	require.Greater(t, node3.eventLoop.tip.block.GetView(), node3TipDuringNetworkHalt.GetView())
+	require.Greater(t, node3.eventLoop.tip.block.GetHeight(), node3TipDuringNetworkHalt.GetHeight())
+}

--- a/consensus/integration_test_utils.go
+++ b/consensus/integration_test_utils.go
@@ -1,0 +1,118 @@
+package consensus
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/deso-protocol/core/bls"
+	"github.com/deso-protocol/core/collections/bitset"
+	"github.com/stretchr/testify/require"
+)
+
+func createDummyBlockWithVoteQC(prevBlockHash BlockHash, view uint64, blockHeight uint64, validators []*validatorNode) *block {
+	signersList := bitset.NewBitset()
+	signatures := []*bls.Signature{}
+
+	// All signers will vote on the previous block has and previous view to build the QC.
+	for ii, validator := range validators {
+		signaturePayload := GetVoteSignaturePayload(view-1, prevBlockHash)
+		signature, _ := validator.privateKey.Sign(signaturePayload[:])
+		signatures = append(signatures, signature)
+		signersList.Set(ii, true)
+	}
+
+	aggregateSignatures, _ := bls.AggregateSignatures(signatures)
+
+	result := block{
+		blockHash: createDummyBlockHash(),
+		view:      view,
+		height:    blockHeight,
+		qc: &quorumCertificate{
+			view:      view - 1,
+			blockHash: prevBlockHash,
+			aggregatedSignature: &aggregatedSignature{
+				signature:   aggregateSignatures,
+				signersList: signersList,
+			},
+		},
+	}
+	return &result
+}
+
+func validateAndPrintBlockChain(t *testing.T, node *validatorNode, allBlocks map[[32]byte]*block) {
+	blockChainString := ""
+
+	// Fetch the validator's tip block
+	tipBlock, ok := allBlocks[node.eventLoop.tip.block.GetBlockHash().GetValue()]
+	require.True(t, ok)
+
+	require.Greater(t, tipBlock.GetView(), uint64(4))   // the network must have advanced more than two views
+	require.Greater(t, tipBlock.GetHeight(), uint64(4)) // the network must have produced at least two blocks
+
+	// Format string that represents the chain of blocks.
+	blockChainString = ""
+
+	// Validate the chain of blocks starting from the tip block and ending at the first block within
+	// the chain.
+	currentBlock := tipBlock
+	parentBlock, hasParentBlock := allBlocks[currentBlock.GetQC().GetBlockHash().GetValue()]
+	for hasParentBlock {
+		// Updated formatted string that represents the chain of blocks.
+		blockHashValue := currentBlock.GetBlockHash().GetValue()
+		blockChainString = fmt.Sprintf(
+			"->(view=%d,height=%d,hash=%s)%s",
+			currentBlock.view,
+			currentBlock.height,
+			hex.EncodeToString(blockHashValue[:2]),
+			blockChainString,
+		)
+
+		// Verify that the current block exists in in the allBlocks map
+		_, ok := allBlocks[currentBlock.GetBlockHash().GetValue()]
+		require.True(t, ok)
+
+		// Cross-validate the current block's and the parent block's views
+		if isInterfaceNil(currentBlock.aggregateQC) {
+			// The current block contains a QC of votes
+			require.Equal(t, currentBlock.GetView(), currentBlock.GetQC().GetView()+1)
+		} else {
+			// The current block contains a timeout QC
+			require.Equal(t, currentBlock.GetView(), currentBlock.aggregateQC.GetView()+1)
+			require.Greater(t, currentBlock.GetView(), currentBlock.aggregateQC.GetHighQC().GetView()+1)
+
+			// The difference in view between the current block and its parent should be equal to the number of
+			// timeout blocks between the current block and its parent.
+			for ii := currentBlock.view - 1; ii > parentBlock.view; ii-- {
+				blockChainString = fmt.Sprintf("->(view=%d,timeout)%s", ii, blockChainString)
+			}
+		}
+
+		// Verify that the current block's height is one more than the parent
+		require.Equal(t, currentBlock.GetHeight(), parentBlock.GetHeight()+1)
+
+		// Move on to the parent block
+		currentBlock = parentBlock
+		parentBlock, hasParentBlock = allBlocks[currentBlock.GetQC().GetBlockHash().GetValue()]
+	}
+
+	// If we get here, we've validated the chain of blocks and reached the first block within the
+	// node's chain. The first block may or may not be the genesis block of the full blockchain,
+	// as the node may have left the network and rejoined at a later time.
+
+	// Format the first block and the node's info.
+	blockHashValue := currentBlock.GetBlockHash().GetValue()
+	blockChainString = fmt.Sprintf(
+		"\nnode=[publicKey=%s, currentView=%d, stake=%s]\nblockchain=[(view=%d,height=%d,hash=%s)%s]\n",
+		node.privateKey.PublicKey().ToString()[:10],
+		node.eventLoop.currentView,
+		node.stake.ToBig().String(),
+		currentBlock.view,
+		currentBlock.height,
+		hex.EncodeToString(blockHashValue[:2]),
+		blockChainString,
+	)
+
+	// Log the formatted string
+	t.Log(blockChainString)
+}


### PR DESCRIPTION
Outputs of integration tests. All resulting block chains from the tests look as expected.
```
/opt/homebrew/bin/go test -timeout 30s -v -run TestNetworkWithOfflineValidators github.com/deso-protocol/core/consensus -tags=relic
=== RUN   TestNetworkWithOfflineValidators
    integration_test_utils.go:116: 
        node=[publicKey=0x85a31e3c, currentView=20, stake=50]
        blockchain=[(view=2,height=2,hash=7a84)->(view=3,height=3,hash=1836)->(view=4,height=4,hash=1f46)->(view=5,height=5,hash=07ac)->(view=6,height=6,hash=ca71)->(view=7,height=7,hash=2779)->(view=8,height=8,hash=1830)->(view=9,height=9,hash=6c72)->(view=10,height=10,hash=85c1)->(view=11,height=11,hash=840b)->(view=12,height=12,hash=b0b4)->(view=13,height=13,hash=6b4b)->(view=14,height=14,hash=b6a7)->(view=15,height=15,hash=3d30)->(view=16,height=16,hash=39db)->(view=17,height=17,hash=97b6)->(view=18,height=18,hash=dbda)->(view=19,height=19,hash=9b48)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0xa55e7684, currentView=20, stake=50]
        blockchain=[(view=12,height=12,hash=b0b4)->(view=13,height=13,hash=6b4b)->(view=14,height=14,hash=b6a7)->(view=15,height=15,hash=3d30)->(view=16,height=16,hash=39db)->(view=17,height=17,hash=97b6)->(view=18,height=18,hash=dbda)->(view=19,height=19,hash=9b48)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0x826360cc, currentView=20, stake=50]
        blockchain=[(view=16,height=16,hash=39db)->(view=17,height=17,hash=97b6)->(view=18,height=18,hash=dbda)->(view=19,height=19,hash=9b48)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0x8c408782, currentView=16, stake=50]
        blockchain=[(view=2,height=2,hash=7a84)->(view=3,height=3,hash=1836)->(view=4,height=4,hash=1f46)->(view=5,height=5,hash=07ac)->(view=6,height=6,hash=ca71)->(view=7,height=7,hash=2779)->(view=8,height=8,hash=1830)->(view=9,height=9,hash=6c72)->(view=10,height=10,hash=85c1)->(view=11,height=11,hash=840b)->(view=12,height=12,hash=b0b4)->(view=13,height=13,hash=6b4b)->(view=14,height=14,hash=b6a7)->(view=15,height=15,hash=3d30)]
        
--- PASS: TestNetworkWithOfflineValidators (2.03s)
```
```
/opt/homebrew/bin/go test -timeout 30s -v -run TestNetworkWithOfflineBlockProposer github.com/deso-protocol/core/consensus -tags=relic
=== RUN   TestNetworkWithOfflineBlockProposer
    integration_test_utils.go:116: 
        node=[publicKey=0xa7f67962, currentView=23, stake=50]
        blockchain=[(view=2,height=2,hash=6448)->(view=3,height=3,hash=674f)->(view=4,height=4,hash=267b)->(view=5,timeout)->(view=6,timeout)->(view=7,height=5,hash=da0a)->(view=8,height=6,hash=a546)->(view=9,height=7,hash=55fe)->(view=10,height=8,hash=127b)->(view=11,height=9,hash=b4f0)->(view=12,height=10,hash=5dde)->(view=13,height=11,hash=c53c)->(view=14,height=12,hash=7697)->(view=15,height=13,hash=10a6)->(view=16,height=14,hash=5e7c)->(view=17,height=15,hash=b9f7)->(view=18,height=16,hash=6c07)->(view=19,height=17,hash=e7b7)->(view=20,height=18,hash=285a)->(view=21,height=19,hash=05fc)->(view=22,height=20,hash=80f6)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0xaa7e3027, currentView=23, stake=50]
        blockchain=[(view=2,height=2,hash=6448)->(view=3,height=3,hash=674f)->(view=4,height=4,hash=267b)->(view=5,timeout)->(view=6,timeout)->(view=7,height=5,hash=da0a)->(view=8,height=6,hash=a546)->(view=9,height=7,hash=55fe)->(view=10,height=8,hash=127b)->(view=11,height=9,hash=b4f0)->(view=12,height=10,hash=5dde)->(view=13,height=11,hash=c53c)->(view=14,height=12,hash=7697)->(view=15,height=13,hash=10a6)->(view=16,height=14,hash=5e7c)->(view=17,height=15,hash=b9f7)->(view=18,height=16,hash=6c07)->(view=19,height=17,hash=e7b7)->(view=20,height=18,hash=285a)->(view=21,height=19,hash=05fc)->(view=22,height=20,hash=80f6)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0xa283564c, currentView=23, stake=50]
        blockchain=[(view=2,height=2,hash=6448)->(view=3,height=3,hash=674f)->(view=4,height=4,hash=267b)->(view=5,timeout)->(view=6,timeout)->(view=7,height=5,hash=da0a)->(view=8,height=6,hash=a546)->(view=9,height=7,hash=55fe)->(view=10,height=8,hash=127b)->(view=11,height=9,hash=b4f0)->(view=12,height=10,hash=5dde)->(view=13,height=11,hash=c53c)->(view=14,height=12,hash=7697)->(view=15,height=13,hash=10a6)->(view=16,height=14,hash=5e7c)->(view=17,height=15,hash=b9f7)->(view=18,height=16,hash=6c07)->(view=19,height=17,hash=e7b7)->(view=20,height=18,hash=285a)->(view=21,height=19,hash=05fc)->(view=22,height=20,hash=80f6)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0x93887ee1, currentView=23, stake=50]
        blockchain=[(view=2,height=2,hash=6448)->(view=3,height=3,hash=674f)->(view=4,height=4,hash=267b)->(view=5,timeout)->(view=6,timeout)->(view=7,height=5,hash=da0a)->(view=8,height=6,hash=a546)->(view=9,height=7,hash=55fe)->(view=10,height=8,hash=127b)->(view=11,height=9,hash=b4f0)->(view=12,height=10,hash=5dde)->(view=13,height=11,hash=c53c)->(view=14,height=12,hash=7697)->(view=15,height=13,hash=10a6)->(view=16,height=14,hash=5e7c)->(view=17,height=15,hash=b9f7)->(view=18,height=16,hash=6c07)->(view=19,height=17,hash=e7b7)->(view=20,height=18,hash=285a)->(view=21,height=19,hash=05fc)->(view=22,height=20,hash=80f6)]
        
--- PASS: TestNetworkWithOfflineBlockProposer (13.02s)
```
```
/opt/homebrew/bin/go test -timeout 30s -v -run TestNetworkRecoveryAfterCatastrophicFailure github.com/deso-protocol/core/consensus -tags=relic
=== RUN   TestNetworkRecoveryAfterCatastrophicFailure
    integration_test_utils.go:116: 
        node=[publicKey=0x88b90c02, currentView=25, stake=10]
        blockchain=[(view=2,height=2,hash=8f47)->(view=3,height=3,hash=b4b3)->(view=4,height=4,hash=be88)->(view=5,timeout)->(view=6,timeout)->(view=7,height=5,hash=0830)->(view=8,height=6,hash=abc4)->(view=9,height=7,hash=8e22)->(view=10,height=8,hash=a75d)->(view=11,height=9,hash=e145)->(view=12,height=10,hash=b510)->(view=13,height=11,hash=35eb)->(view=14,height=12,hash=926a)->(view=15,height=13,hash=df71)->(view=16,height=14,hash=0b71)->(view=17,height=15,hash=ba11)->(view=18,height=16,hash=0b6d)->(view=19,height=17,hash=7b01)->(view=20,height=18,hash=afd0)->(view=21,height=19,hash=4e86)->(view=22,height=20,hash=d2f3)->(view=23,height=21,hash=59dc)->(view=24,height=22,hash=eec3)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0x9830cca4, currentView=25, stake=10]
        blockchain=[(view=2,height=2,hash=8f47)->(view=3,height=3,hash=b4b3)->(view=4,height=4,hash=be88)->(view=5,timeout)->(view=6,timeout)->(view=7,height=5,hash=0830)->(view=8,height=6,hash=abc4)->(view=9,height=7,hash=8e22)->(view=10,height=8,hash=a75d)->(view=11,height=9,hash=e145)->(view=12,height=10,hash=b510)->(view=13,height=11,hash=35eb)->(view=14,height=12,hash=926a)->(view=15,height=13,hash=df71)->(view=16,height=14,hash=0b71)->(view=17,height=15,hash=ba11)->(view=18,height=16,hash=0b6d)->(view=19,height=17,hash=7b01)->(view=20,height=18,hash=afd0)->(view=21,height=19,hash=4e86)->(view=22,height=20,hash=d2f3)->(view=23,height=21,hash=59dc)->(view=24,height=22,hash=eec3)]
        
    integration_test_utils.go:116: 
        node=[publicKey=0x8789489c, currentView=25, stake=80]
        blockchain=[(view=2,height=2,hash=8f47)->(view=3,height=3,hash=b4b3)->(view=4,height=4,hash=be88)->(view=5,timeout)->(view=6,timeout)->(view=7,height=5,hash=0830)->(view=8,height=6,hash=abc4)->(view=9,height=7,hash=8e22)->(view=10,height=8,hash=a75d)->(view=11,height=9,hash=e145)->(view=12,height=10,hash=b510)->(view=13,height=11,hash=35eb)->(view=14,height=12,hash=926a)->(view=15,height=13,hash=df71)->(view=16,height=14,hash=0b71)->(view=17,height=15,hash=ba11)->(view=18,height=16,hash=0b6d)->(view=19,height=17,hash=7b01)->(view=20,height=18,hash=afd0)->(view=21,height=19,hash=4e86)->(view=22,height=20,hash=d2f3)->(view=23,height=21,hash=59dc)->(view=24,height=22,hash=eec3)]
        
--- PASS: TestNetworkRecoveryAfterCatastrophicFailure (13.02s)
```