### PR TITLE
All Block rewards mature immediately - no need to write block rewards to index

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4399,6 +4399,15 @@ func (bav *UtxoView) GetUnspentUtxoEntrysForPublicKey(pkBytes []byte) ([]*UtxoEn
 // but should be fixed soon.
 func (bav *UtxoView) GetSpendableDeSoBalanceNanosForPublicKey(pkBytes []byte,
 	tipHeight uint32) (_spendableBalance uint64, _err error) {
+	// After the cut-over to Proof Of Stake, we no longer check for immature block rewards.
+	// All block rewards are immediately mature.
+	if tipHeight >= bav.Params.ForkHeights.ProofOfStake2ConsensusCutoverBlockHeight {
+		balanceNanos, err := bav.GetDeSoBalanceNanosForPublicKey(pkBytes)
+		if err != nil {
+			return 0, errors.Wrap(err, "GetSpendableDeSoBalanceNanosForPublicKey: ")
+		}
+		return balanceNanos, nil
+	}
 	// In order to get the spendable balance, we need to account for any immature block rewards.
 	// We get these by starting at the chain tip and iterating backwards until we have collected
 	// all the immature block rewards for this public key.

--- a/lib/blockchain_test.go
+++ b/lib/blockchain_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"math/big"
 	"math/rand"
 	"os"
@@ -451,7 +452,9 @@ func _getBalanceWithView(t *testing.T, chain *Blockchain, utxoView *UtxoView, pk
 
 func TestBalanceModelBlockTests(t *testing.T) {
 	setBalanceModelBlockHeights(t)
-
+	// This test assumes we're using PoW blocks, and thus we need to set the PoS cut-over
+	// fork height to some distant future height
+	DeSoTestnetParams.ForkHeights.ProofOfStake2ConsensusCutoverBlockHeight = math.MaxUint32
 	t.Run("TestBasicTransferReorg", TestBasicTransferReorg)
 	t.Run("TestProcessBlockConnectBlocks", TestProcessBlockConnectBlocks)
 	t.Run("TestProcessHeaderskReorgBlocks", TestProcessHeaderskReorgBlocks)


### PR DESCRIPTION
The block rewards index is also part of the state synced by hypersync, so this also solves the issue of storing blocks that are not part of the best chain.