### PR TITLE
Use block's header as timestamp when connecting transactions in connect block Use mempool's Added timestamp for state syncer mempool syncing

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4051,7 +4051,9 @@ func (bav *UtxoView) ConnectBlock(
 		// would slow down block processing significantly. We should figure out a way to
 		// enforce this check in the future, but for now the only attack vector is one in
 		// which a miner is trying to spam the network, which should generally never happen.
-		utxoOpsForTxn, totalInput, totalOutput, currentFees, err := bav.ConnectTransaction(txn, txHash, 0, uint32(blockHeader.Height), int64(blockHeader.TstampNanoSecs), verifySignatures, false)
+		utxoOpsForTxn, totalInput, totalOutput, currentFees, err := bav.ConnectTransaction(
+			txn, txHash, int64(desoBlock.Header.TstampNanoSecs), uint32(blockHeader.Height),
+			int64(blockHeader.TstampNanoSecs), verifySignatures, false)
 		_, _ = totalInput, totalOutput // A bit surprising we don't use these
 		if err != nil {
 			return nil, errors.Wrapf(err, "ConnectBlock: error connecting txn #%d", txIndex)

--- a/lib/state_change_syncer.go
+++ b/lib/state_change_syncer.go
@@ -688,7 +688,7 @@ func (stateChangeSyncer *StateChangeSyncer) SyncMempoolToStateSyncer(server *Ser
 	currentTimestamp := time.Now().UnixNano()
 	for _, mempoolTx := range mempoolTxns {
 		utxoOpsForTxn, _, _, _, err := mempoolTxUtxoView.ConnectTransaction(
-			mempoolTx.Tx, mempoolTx.Hash, 0, uint32(blockHeight+1),
+			mempoolTx.Tx, mempoolTx.Hash, mempoolTx.Added.UnixNano(), uint32(blockHeight+1),
 			currentTimestamp, false, false /*ignoreUtxos*/)
 		if err != nil {
 			return false, errors.Wrapf(err, "StateChangeSyncer.SyncMempoolToStateSyncer ConnectTransaction: ")


### PR DESCRIPTION
Use mempool's Added timestamp for state syncer mempool syncing