### PR TITLE
Support bulk block download

### DIFF
--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -1756,7 +1756,7 @@ func (bav *UtxoView) IsValidRegisterAsValidatorMetadata(
 	for _, domain := range metadata.Domains {
 		_, err := url.ParseRequestURI(string(domain))
 		if err != nil {
-			return fmt.Errorf("UtxoView.IsValidRegisterAsValidatorMetadata: %s: %v", RuleErrorValidatorInvalidDomain, domain)
+			return fmt.Errorf("UtxoView.IsValidRegisterAsValidatorMetadata: %s: %v", RuleErrorValidatorInvalidDomain, string(domain))
 		}
 		domainStrings = append(domainStrings, string(domain))
 	}

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -5,7 +5,6 @@ import (
 	"container/list"
 	"encoding/hex"
 	"fmt"
-	"github.com/decred/dcrd/lru"
 	"math"
 	"math/big"
 	"reflect"
@@ -13,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/decred/dcrd/lru"
 
 	"github.com/deso-protocol/core/collections"
 
@@ -975,11 +976,13 @@ func locateHeaders(locator []*BlockHash, stopHash *BlockHash, maxHeaders uint32,
 //     after the genesis block will be returned
 //
 // This function is safe for concurrent access.
-func (bc *Blockchain) LocateBestBlockChainHeaders(locator []*BlockHash, stopHash *BlockHash) []*MsgDeSoHeader {
+func (bc *Blockchain) LocateBestBlockChainHeaders(
+	locator []*BlockHash, stopHash *BlockHash, maxHeaders uint32) []*MsgDeSoHeader {
+
 	// TODO: Shouldn't we hold a ChainLock here? I think it's fine though because the place
 	// where it's currently called is single-threaded via a channel in server.go. Going to
 	// avoid messing with it for now.
-	headers := locateHeaders(locator, stopHash, MaxHeadersPerMsg,
+	headers := locateHeaders(locator, stopHash, maxHeaders,
 		bc.blockIndexByHash, bc.bestChain, bc.bestChainMap)
 
 	return headers

--- a/lib/network.go
+++ b/lib/network.go
@@ -44,6 +44,12 @@ var MaxBlockRewardDataSizeBytes = 250
 // MaxHeadersPerMsg is the maximum numbers allowed in a GetHeaders response.
 var MaxHeadersPerMsg = uint32(2000)
 
+// With PoS we can afford to download more headers in each batch.
+//
+// TODO: I set this number really high because it's easier to lower it than it is
+// to increase it (increasing requires everyone to upgrade).
+var MaxHeadersPerMsgPos = uint32(200000)
+
 // MaxBitcoinHeadersPerMsg is the maximum number of headers Bitcoin allows in
 // a getheaders response. It is used to determine whether a node has more headers
 // to give us.

--- a/lib/network_test.go
+++ b/lib/network_test.go
@@ -3,8 +3,6 @@ package lib
 import (
 	"bytes"
 	"encoding/hex"
-	"github.com/deso-protocol/core/bls"
-	"golang.org/x/crypto/sha3"
 	"math/big"
 	"math/rand"
 	"reflect"
@@ -12,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/deso-protocol/core/bls"
+	"golang.org/x/crypto/sha3"
 
 	"github.com/holiman/uint256"
 
@@ -615,6 +616,19 @@ func TestBlockSerialize(t *testing.T) {
 		require.Equal(*block, *testBlock)
 	}
 
+	// Also test MsgDeSoBlockBundle
+	bundle := &MsgDeSoBlockBundle{
+		Blocks: expectedBlocksToTest,
+		// Just fill any old data for these
+		TipHash:   expectedBlocksToTest[0].Header.PrevBlockHash,
+		TipHeight: expectedBlocksToTest[0].Header.Height,
+	}
+	bb, err := bundle.ToBytes(false)
+	require.NoError(err)
+	testBundle := &MsgDeSoBlockBundle{}
+	err = testBundle.FromBytes(bb)
+	require.NoError(err)
+	require.Equal(bundle, testBundle)
 }
 
 func TestBlockSerializeNoBlockProducerInfo(t *testing.T) {

--- a/lib/peer.go
+++ b/lib/peer.go
@@ -2,12 +2,13 @@ package lib
 
 import (
 	"fmt"
-	"github.com/decred/dcrd/lru"
 	"net"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/decred/dcrd/lru"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/deso-protocol/go-deadlock"
@@ -394,29 +395,52 @@ func (pp *Peer) HandleGetBlocks(msg *MsgDeSoGetBlocks) {
 		return
 	}
 
-	// For each block the Peer has requested, fetch it and queue it to
-	// be sent. It takes some time to fetch the blocks which is why we
-	// do it in a goroutine. This might also block if the Peer's send
-	// queue is full.
-	//
-	// Note that the requester should generally ask for the blocks in the
-	// order they'd like to receive them as we will typically honor this
-	// ordering.
-	//
-	// With HyperSync there is a potential that a node will request blocks that we haven't yet stored, although we're
-	// fully synced. This can happen to archival nodes that haven't yet downloaded all historical blocks. If a GetBlock
-	// is sent to a non-archival node for blocks that we don't have, then the peer is misbehaving and should be disconnected.
-	for _, hashToSend := range msg.HashList {
-		blockToSend := pp.srv.blockchain.GetBlock(hashToSend)
-		if blockToSend == nil {
-			// Don't ask us for blocks before verifying that we have them with a
-			// GetHeaders request.
-			glog.Errorf("Server._handleGetBlocks: Disconnecting peer %v because "+
-				"she asked for a block with hash %v that we don't have", pp, msg.HashList[0])
-			pp.Disconnect()
-			return
+	// Before Version2 we would send each block in a single message, which was quite
+	// slow. Now when we receive a GetBlocks message we will send the blocks in large
+	// batches, which is much faster.
+	if pp.Params.ProtocolVersion == ProtocolVersion2 {
+		allBlocks := MsgDeSoBlockBundle{}
+		for _, hashToSend := range msg.HashList {
+			blockToSend := pp.srv.blockchain.GetBlock(hashToSend)
+			if blockToSend == nil {
+				// Don't ask us for blocks before verifying that we have them with a
+				// GetHeaders request.
+				glog.Errorf("Server._handleGetBlocks: Disconnecting peer %v because "+
+					"she asked for a block with hash %v that we don't have", pp, msg.HashList[0])
+				pp.Disconnect()
+				return
+			}
+			allBlocks.Blocks = append(allBlocks.Blocks, blockToSend)
 		}
-		pp.AddDeSoMessage(blockToSend, false)
+		allBlocks.TipHash = pp.srv.blockchain.blockTip().Hash
+		allBlocks.TipHeight = uint64(pp.srv.blockchain.blockTip().Height)
+		pp.AddDeSoMessage(&allBlocks, false)
+
+	} else {
+		// For each block the Peer has requested, fetch it and queue it to
+		// be sent. It takes some time to fetch the blocks which is why we
+		// do it in a goroutine. This might also block if the Peer's send
+		// queue is full.
+		//
+		// Note that the requester should generally ask for the blocks in the
+		// order they'd like to receive them as we will typically honor this
+		// ordering.
+		//
+		// With HyperSync there is a potential that a node will request blocks that we haven't yet stored, although we're
+		// fully synced. This can happen to archival nodes that haven't yet downloaded all historical blocks. If a GetBlock
+		// is sent to a non-archival node for blocks that we don't have, then the peer is misbehaving and should be disconnected.
+		for _, hashToSend := range msg.HashList {
+			blockToSend := pp.srv.blockchain.GetBlock(hashToSend)
+			if blockToSend == nil {
+				// Don't ask us for blocks before verifying that we have them with a
+				// GetHeaders request.
+				glog.Errorf("Server._handleGetBlocks: Disconnecting peer %v because "+
+					"she asked for a block with hash %v that we don't have", pp, msg.HashList[0])
+				pp.Disconnect()
+				return
+			}
+			pp.AddDeSoMessage(blockToSend, false)
+		}
 	}
 }
 
@@ -1007,11 +1031,14 @@ func (pp *Peer) _maybeAddBlocksToSend(msg DeSoMessage) error {
 
 	// If the peer has exceeded the number of blocks she is allowed to request
 	// then disconnect her.
-	if len(pp.blocksToSend) > MaxBlocksInFlight {
+	//
+	// We can safely increase this without breaking backwards-compatibility because old
+	// nodes will never send us more hashes than this.
+	if len(pp.blocksToSend) > MaxBlocksInFlightPoS {
 		pp.Disconnect()
 		return fmt.Errorf("_maybeAddBlocksToSend: Disconnecting peer %v because she requested %d "+
 			"blocks, which is more than the %d blocks allowed "+
-			"in flight", pp, len(pp.blocksToSend), MaxBlocksInFlight)
+			"in flight", pp, len(pp.blocksToSend), MaxBlocksInFlightPoS)
 	}
 
 	return nil

--- a/lib/pos_server_regtest.go
+++ b/lib/pos_server_regtest.go
@@ -26,9 +26,9 @@ func (srv *Server) submitRegtestValidatorRegistrationTxns(block *MsgDeSoBlock) {
 
 		var domain string
 		if len(srv.GetConnectionManager().listeners) == 0 {
-			domain = "localhost:18000"
+			domain = "http://localhost:18000"
 		}
-		domain = srv.GetConnectionManager().listeners[0].Addr().String()
+		domain = "http://" + srv.GetConnectionManager().listeners[0].Addr().String()
 
 		txnMeta := RegisterAsValidatorMetadata{
 			Domains:                             [][]byte{[]byte(domain)},

--- a/lib/server.go
+++ b/lib/server.go
@@ -884,7 +884,14 @@ func (srv *Server) GetBlocksToStore(pp *Peer) {
 // SyncStateSyncingHeaders.
 func (srv *Server) GetBlocks(pp *Peer, maxHeight int) {
 	// Fetch as many blocks as we can from this peer.
-	numBlocksToFetch := MaxBlocksInFlight - len(pp.requestedBlocks)
+	// If our peer is on PoS then we can safely request a lot more blocks from them in
+	// each flight.
+	maxBlocksInFlight := MaxBlocksInFlight
+	if pp.Params.ProtocolVersion >= ProtocolVersion2 {
+		maxBlocksInFlight = MaxBlocksInFlightPoS
+	}
+	numBlocksToFetch := maxBlocksInFlight - len(pp.requestedBlocks)
+
 	blockNodesToFetch := srv.blockchain.GetBlockNodesToFetch(
 		numBlocksToFetch, maxHeight, pp.requestedBlocks)
 	if len(blockNodesToFetch) == 0 {
@@ -2074,10 +2081,14 @@ func (srv *Server) _logAndDisconnectPeer(pp *Peer, blockMsg *MsgDeSoBlock, suffi
 	pp.Disconnect()
 }
 
-func (srv *Server) _handleBlock(pp *Peer, blk *MsgDeSoBlock) {
-	glog.Infof(CLog(Cyan, fmt.Sprintf("Server._handleBlock: Received block ( %v / %v ) from Peer %v",
-		blk.Header.Height, srv.blockchain.headerTip().Height, pp)))
-
+// This function handles a single block that we receive from our peer. Originally, we would receive blocks
+// one by one from our peer. However, now we receive a batch of blocks all at once via _handleBlockBundle,
+// which then calls this function to process them one by one on our side.
+//
+// isLastBlock indicates that this is the last block in the list of blocks we received back
+// via a MsgDeSoBlockBundle message. When we receive a single block, isLastBlock will automatically
+// be true, which will give it its old single-block behavior.
+func (srv *Server) _handleBlock(pp *Peer, blk *MsgDeSoBlock, isLastBlock bool) {
 	srv.timer.Start("Server._handleBlock: General")
 
 	// Pull out the header for easy access.
@@ -2190,6 +2201,13 @@ func (srv *Server) _handleBlock(pp *Peer, blk *MsgDeSoBlock) {
 	srv.timer.Print("Server._handleBlock: General")
 	srv.timer.Print("Server._handleBlock: Process Block")
 
+	// If we're not at the last block yet, then we're done. The rest of this code is only
+	// relevant after we've connected the last block, and it generally involves fetching
+	// more data from our peer.
+	if !isLastBlock {
+		return
+	}
+
 	// We shouldn't be receiving blocks while syncing headers, but we can end up here
 	// if it took longer than MaxTipAge to sync blocks to this point. We'll revert to
 	// syncing headers and then resume syncing blocks once we're current again.
@@ -2260,6 +2278,50 @@ func (srv *Server) _handleBlock(pp *Peer, blk *MsgDeSoBlock) {
 
 	// If the chain is current, then try to transition to the FastHotStuff consensus.
 	srv.tryTransitionToFastHotStuffConsensus()
+}
+
+func (srv *Server) _handleBlockBundle(pp *Peer, bundle *MsgDeSoBlockBundle) {
+	if len(bundle.Blocks) == 0 {
+		glog.Infof(CLog(Cyan, fmt.Sprintf("Server._handleBlockBundle: Received EMPTY block bundle "+
+			"at header height ( %v ) from Peer %v. Disconnecting peer since this should never happen.",
+			srv.blockchain.headerTip().Height, pp)))
+		pp.Disconnect()
+		return
+	}
+	glog.Infof(CLog(Cyan, fmt.Sprintf("Server._handleBlockBundle: Received blocks ( %v->%v / %v ) from Peer %v",
+		bundle.Blocks[0].Header.Height, bundle.Blocks[len(bundle.Blocks)-1].Header.Height,
+		srv.blockchain.headerTip().Height, pp)))
+
+	srv.timer.Start("Server._handleBlockBundle: General")
+
+	// TODO: We should fetch the next batch of blocks while we process this batch.
+	// This requires us to modify GetBlocks to take a start hash and a count
+	// of the number of blocks we want. Or we could make the existing GetBlocks
+	// take a start hash and the other node can just return as many blcoks as it
+	// can.
+
+	// Process each block in the bundle. Record our blocks per second.
+	blockProcessingStartTime := time.Now()
+	for ii, blk := range bundle.Blocks {
+		// TODO: We should make it so that we break out if one of the blocks errors. It's just that
+		// _handleBlock is a legacy function that doesn't support erroring out. It's not a big deal
+		// though as we'll just connect all the blocks after the failed one and those blocks will also
+		// gracefully fail.
+		srv._handleBlock(pp, blk, ii == len(bundle.Blocks)-1 /*isLastBlock*/)
+		numLogBlocks := 1000
+		if ii%numLogBlocks == 0 {
+			glog.Infof(CLog(Cyan, fmt.Sprintf("Server._handleBlockBundle: Processed block ( %v / %v ) = ( %v / %v ) from Peer %v",
+				bundle.Blocks[ii].Header.Height,
+				srv.blockchain.headerTip().Height,
+				ii+1, len(bundle.Blocks),
+				pp)))
+
+			elapsed := time.Since(blockProcessingStartTime)
+			if ii != 0 {
+				fmt.Printf("We are processing %v blocks per second\n", float64(ii)/(float64(elapsed)/1e9))
+			}
+		}
+	}
 }
 
 func (srv *Server) _handleInv(peer *Peer, msg *MsgDeSoInv) {
@@ -2561,10 +2623,13 @@ func (srv *Server) _handlePeerMessages(serverMessage *ServerMessage) {
 		srv._handleGetHeaders(serverMessage.Peer, msg)
 	case *MsgDeSoHeaderBundle:
 		srv._handleHeaderBundle(serverMessage.Peer, msg)
+	case *MsgDeSoBlockBundle:
+		srv._handleBlockBundle(serverMessage.Peer, msg)
 	case *MsgDeSoGetBlocks:
 		srv._handleGetBlocks(serverMessage.Peer, msg)
 	case *MsgDeSoBlock:
-		srv._handleBlock(serverMessage.Peer, msg)
+		// isLastBlock is always true when we get a legacy single-block message.
+		srv._handleBlock(serverMessage.Peer, msg, true)
 	case *MsgDeSoGetSnapshot:
 		srv._handleGetSnapshot(serverMessage.Peer, msg)
 	case *MsgDeSoSnapshotData:


### PR DESCRIPTION
Originally during syncing we would download blocks from our sync peer one at a time, which was slow. This PR upgrades PoS nodes to download blocks in batches via a minimally-invasive change that has a low likelihood of breaking anything.

This upgrade has been tested between two PoS regtest nodes as well as a PoS node syncing from an existing testnet node. They both worked like a dream.