### PR TITLE
Fix minor issues to speed up block processing logic

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/btcsuite/btcd/wire"
 	"math"
 	"math/big"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/btcsuite/btcd/wire"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -3355,12 +3356,15 @@ func (bav *UtxoView) ConnectBlock(
 	desoBlock *MsgDeSoBlock, txHashes []*BlockHash, verifySignatures bool, eventManager *EventManager, blockHeight uint64) (
 	[][]*UtxoOperation, error) {
 
-	glog.V(1).Infof("ConnectBlock: Connecting block %v", desoBlock)
+	glog.V(1).Infof("ConnectBlock: Connecting block %v with %v txns", desoBlock, len(desoBlock.Txns))
 
 	// Check that the block being connected references the current tip. ConnectBlock
 	// can only add a block to the current tip. We do this to keep the API simple.
 	if *desoBlock.Header.PrevBlockHash != *bav.TipHash {
-		return nil, fmt.Errorf("ConnectBlock: Parent hash of block being connected does not match tip")
+		errorMsg := fmt.Sprintf("ConnectBlock: Parent hash of block being connected does not match tip: %v vs %v",
+			hex.EncodeToString(desoBlock.Header.PrevBlockHash[:]), hex.EncodeToString(bav.TipHash[:]))
+		glog.V(1).Infof("ConnectBlock: Parent hash of block being connected does not match tip: %v", errorMsg)
+		return nil, fmt.Errorf(errorMsg)
 	}
 
 	blockHeader := desoBlock.Header

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -5,8 +5,6 @@ import (
 	"container/list"
 	"encoding/hex"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/holiman/uint256"
 	"math"
 	"math/big"
 	"reflect"
@@ -14,6 +12,9 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/holiman/uint256"
 
 	btcdchain "github.com/btcsuite/btcd/blockchain"
 	chainlib "github.com/btcsuite/btcd/blockchain"

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -3,7 +3,6 @@ package lib
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/pkg/errors"
 	"log"
 	"math/big"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"regexp"
 	"sort"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/holiman/uint256"
 
@@ -905,7 +906,7 @@ var DeSoMainnetParams = DeSoParams{
 	// We set this to be lower initially to avoid winding up with really big
 	// spam blocks in the event someone tries to abuse the initially low min
 	// fee rates.
-	MinerMaxBlockSizeBytes: 2000000,
+	MinerMaxBlockSizeBytes: 500000,
 
 	// This takes about ten seconds on a reasonable CPU, which makes sense given
 	// a 10 minute block time.

--- a/lib/mempool.go
+++ b/lib/mempool.go
@@ -6,8 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/btcsuite/btcutil"
-	"github.com/gernest/mention"
 	"log"
 	"math"
 	"os"
@@ -17,6 +15,9 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/btcsuite/btcutil"
+	"github.com/gernest/mention"
 
 	"github.com/dgraph-io/badger/v3"
 


### PR DESCRIPTION
* Fix a bug whereby block production would not start until the first call to SubmitBlock, which resulted in erratic miner behavior. Specifically, all calls to get-block-template would fail until the first call to submit-block. Normally in the steady-state this is not an issue, but during a reboot it can become a "chicken and egg" where miners need get-block-template to generate a valid block, but get-block-template won't return until they actually produce a block (which they can't do without a template).

* Reduce the default block size used by miners to 500kb, down from 2mb. This ends up giving better performance during periods of high congestion because smaller blocks are processed more quickly. With very large blocks, we were encountering an issue whereby a block would take a minute or two to fuly validate, causing erratic behavior as the block propagated through the network.

* Add a rest period during initial transaction download that allows for other processes to grab the ChainLock if needed. This was the least obviously-needed of the fixes, but it doesn't hurt to leave it in, and could prevent deadlock-related issues during periods of high congestion.

* Add more useful logging in various places.