### PR TITLE
Speed up blocksync by only writing to db when an entry has changed

### DIFF
--- a/lib/block_view_stake.go
+++ b/lib/block_view_stake.go
@@ -912,7 +912,14 @@ func DBGetLockedStakeEntriesInRangeWithTxn(
 	return lockedStakeEntries, nil
 }
 
-func DBPutStakeEntryWithTxn(
+// In order to optimize the flush, we want to only write entries to the db that have changed.
+// On top of that, we add a further optimization to only update the
+// PrefixStakeByStakeAmount index if the stake amount has changed. Not doing this results
+// in a lot of writes to badger every epoch that eventually slow block processing to a crawl.
+// This is essentially a bug in badger when you repeatedly write to the same key, and we're
+// papering over it here in response to encountering the issue. In an ideal world, badger
+// would work as intended and this extra optimization wouldn't be necessary.
+func DBUpdateStakeEntryWithTxn(
 	txn *badger.Txn,
 	snap *Snapshot,
 	stakeEntry *StakeEntry,
@@ -923,20 +930,50 @@ func DBPutStakeEntryWithTxn(
 		return nil
 	}
 
-	// Set StakeEntry in PrefixStakeByValidatorByStaker.
+	// Fetch the existing entry from the db so we can potentially avoid an update
+	dbEntry, err := DBGetStakeEntryWithTxn(
+		txn, snap, stakeEntry.ValidatorPKID, stakeEntry.StakerPKID)
+	if err != nil {
+		return errors.Wrapf(err, "_flushStakeEntriesToDbWithTxn: ")
+	}
+	dbEntryBytes := EncodeToBytes(blockHeight, dbEntry)
+	// Serialize the entry to bytes
+	entryToWriteBytes := EncodeToBytes(blockHeight, stakeEntry)
+	// If the entry we're about to write is the exact same as what's already in the db then
+	// don't write it.
+	if bytes.Equal(dbEntryBytes, entryToWriteBytes) {
+		return nil
+	}
+
+	// Set StakeEntry in PrefixStakeByValidatorByStaker. This should gracefully overwrite an existing entry
+	// if one exists so no need to delete before adding it.
 	stakeByValidatorAndStakerKey := DBKeyForStakeByValidatorAndStaker(stakeEntry.ValidatorPKID, stakeEntry.StakerPKID)
 	if err := DBSetWithTxn(txn, snap, stakeByValidatorAndStakerKey, EncodeToBytes(blockHeight, stakeEntry), eventManager); err != nil {
 		return errors.Wrapf(
-			err, "DBPutStakeEntryWithTxn: problem storing StakeEntry in index PrefixStakeByValidatorByStaker: ",
+			err, "DBUpdateStakeEntryWithTxn: problem storing StakeEntry in index PrefixStakeByValidatorByStaker: ",
 		)
 	}
 
-	// Set StakeEntry in PrefixStakeByStakeAmount.
-	stakeByStakeAmountKey := DBKeyForStakeByStakeAmount(stakeEntry)
-	if err := DBSetWithTxn(txn, snap, stakeByStakeAmountKey, nil, eventManager); err != nil {
-		return errors.Wrapf(
-			err, "DBPutStakeEntryWithTxn: problem storing StakeEntry in index PrefixStakeByStakeAmount: ",
-		)
+	// Set StakeEntry in PrefixStakeByStakeAmount but only if the amount has changed.
+	if dbEntry == nil || dbEntry.StakeAmountNanos.Cmp(stakeEntry.StakeAmountNanos) != 0 {
+		// Delete the existing entry in the db index if one exists
+		if dbEntry != nil {
+			dbStakeByStakeAmountKey := DBKeyForStakeByStakeAmount(dbEntry)
+			// Note we set isDeleted=false as a hint to the state syncer that we're about to
+			// update this value immediately after.
+			if err := DBDeleteWithTxn(txn, snap, dbStakeByStakeAmountKey, eventManager, false); err != nil {
+				return errors.Wrapf(
+					err, "DBDeleteStakeEntryWithTxn: problem deleting StakeEntry from index PrefixStakeByStakeAmount: ",
+				)
+			}
+		}
+
+		stakeByStakeAmountKey := DBKeyForStakeByStakeAmount(stakeEntry)
+		if err := DBSetWithTxn(txn, snap, stakeByStakeAmountKey, nil, eventManager); err != nil {
+			return errors.Wrapf(
+				err, "DBUpdateStakeEntryWithTxn: problem storing StakeEntry in index PrefixStakeByStakeAmount: ",
+			)
+		}
 	}
 
 	return nil
@@ -2719,7 +2756,8 @@ func (bav *UtxoView) _deleteLockedStakeEntryMappings(lockedStakeEntry *LockedSta
 }
 
 func (bav *UtxoView) _flushStakeEntriesToDbWithTxn(txn *badger.Txn, blockHeight uint64) error {
-	// Delete all entries in the UtxoView map.
+	// Iterate through all the entries in the view. Delete the entries that have isDeleted=true
+	// and update the entries that don't.
 	for mapKeyIter, entryIter := range bav.StakeMapKeyToStakeEntry {
 		// Make a copy of the iterators since we make references to them below.
 		mapKey := mapKeyIter
@@ -2737,21 +2775,12 @@ func (bav *UtxoView) _flushStakeEntriesToDbWithTxn(txn *badger.Txn, blockHeight 
 
 		// Delete the existing mappings in the db for this MapKey. They will be
 		// re-added if the corresponding entry in-memory has isDeleted=false.
-		if err := DBDeleteStakeEntryWithTxn(txn, bav.Snapshot, entry.ValidatorPKID, entry.StakerPKID, blockHeight, bav.EventManager, entry.isDeleted); err != nil {
-			return errors.Wrapf(err, "_flushStakeEntriesToDbWithTxn: ")
-		}
-	}
-
-	// Set any !isDeleted entries in the UtxoView map.
-	for _, entryIter := range bav.StakeMapKeyToStakeEntry {
-		entry := *entryIter
 		if entry.isDeleted {
-			// If isDeleted then there's nothing to do because
-			// we already deleted the entry above.
+			if err := DBDeleteStakeEntryWithTxn(txn, bav.Snapshot, entry.ValidatorPKID, entry.StakerPKID, blockHeight, bav.EventManager, entry.isDeleted); err != nil {
+				return errors.Wrapf(err, "_flushStakeEntriesToDbWithTxn: ")
+			}
 		} else {
-			// If !isDeleted then we put the corresponding
-			// mappings for it into the db.
-			if err := DBPutStakeEntryWithTxn(txn, bav.Snapshot, &entry, blockHeight, bav.EventManager); err != nil {
+			if err := DBUpdateStakeEntryWithTxn(txn, bav.Snapshot, &entry, blockHeight, bav.EventManager); err != nil {
 				return errors.Wrapf(err, "_flushStakeEntriesToDbWithTxn: ")
 			}
 		}

--- a/lib/block_view_validator.go
+++ b/lib/block_view_validator.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"github.com/deso-protocol/core/consensus"
 	"io"
 	"math"
 	"net/url"
 	"sort"
-
-	"github.com/deso-protocol/core/consensus"
 
 	"github.com/deso-protocol/core/bls"
 	"github.com/dgraph-io/badger/v4"
@@ -773,7 +772,15 @@ func DBGetTopActiveValidatorsByStakeAmount(
 	return validatorEntries, nil
 }
 
-func DBPutValidatorWithTxn(
+// In order to optimize the flush, we want to only write entries to the db that have changed.
+// On top of that, we add a further optimization to only update the
+// PrefixValidatorByStatusAndStakeAmount index if the stake amount or status has changed in the
+// validator. Not doing this results in a lot of writes to badger
+// every epoch that eventually slow block processing to a crawl. This is essentially a bug in
+// badger when you repeatedly write to the same key, and we're papering over it here in response
+// to encountering the issue. In an ideal world, badger would work as intended and this extra
+// optimization wouldn't be necessary.
+func DBUpdateValidatorWithTxn(
 	txn *badger.Txn,
 	snap *Snapshot,
 	validatorEntry *ValidatorEntry,
@@ -786,7 +793,28 @@ func DBPutValidatorWithTxn(
 		return nil
 	}
 
-	// Set ValidatorEntry in PrefixValidatorByPKID.
+	// Look up the existing ValidatorEntry from the db
+	dbEntry, err := DBGetValidatorByPKIDWithTxn(txn, snap, validatorEntry.ValidatorPKID)
+	if err != nil {
+		return errors.Wrapf(err, "DBUpdateValidatorWithTxn: ")
+	}
+	dbEntryBytes := EncodeToBytes(blockHeight, dbEntry)
+
+	entryToWriteBytes := EncodeToBytes(blockHeight, validatorEntry)
+	// If the entry we're about to write is the exact same as what's already in the db then
+	// don't write it.
+	//
+	// In 99%+ of cases, the entries will be identical so we save a lot from
+	// this optimization, and it significantly speeds up block processing ot have it. When they
+	// differ, typically it's only because of LastActiveAtEpochNumber. For this reason, we have
+	// a secondary optimization to only update the PrefixValidatorByStatusAndStakeAmount index
+	// when absolutely necessary.
+	if bytes.Equal(dbEntryBytes, entryToWriteBytes) {
+		return nil
+	}
+
+	// Set ValidatorEntry in PrefixValidatorByPKID. This should gracefully overwrite an existing entry
+	// if one exists.
 	key := DBKeyForValidatorByPKID(validatorEntry)
 	if err := DBSetWithTxn(txn, snap, key, EncodeToBytes(blockHeight, validatorEntry), eventManager); err != nil {
 		return errors.Wrapf(
@@ -794,13 +822,33 @@ func DBPutValidatorWithTxn(
 		)
 	}
 
-	// Set ValidatorEntry key in PrefixValidatorByStatusAndStakeAmount. The value should be nil.
-	// We parse the ValidatorPKID from the key for this index.
-	key = DBKeyForValidatorByStatusAndStakeAmount(validatorEntry)
-	if err := DBSetWithTxn(txn, snap, key, nil, eventManager); err != nil {
-		return errors.Wrapf(
-			err, "DBPutValidatorWithTxn: problem storing ValidatorEntry in index PrefixValidatorByStatusAndStakeAmount",
-		)
+	// If the entry we're about to write has the exact same stake amount and the exact same status,
+	// then there is no need to update PrefixValidatorByStatusAndStakeAmount. This saves us a lot in terms
+	// of block processing time due to the aforementioned badger bug.
+	if dbEntry == nil || validatorEntry.TotalStakeAmountNanos.Cmp(dbEntry.TotalStakeAmountNanos) != 0 ||
+		validatorEntry.Status() != dbEntry.Status() {
+
+		// Here we need to delete the existing value in the index first
+		if dbEntry != nil {
+			key = DBKeyForValidatorByStatusAndStakeAmount(dbEntry)
+			// Note we set isDeleted=false as a hint to the state syncer that we're about to
+			// update this value immediately after.
+			if err := DBDeleteWithTxn(txn, snap, key, eventManager, false); err != nil {
+				return errors.Wrapf(
+					err, "DBUpdateValidatorWithTxn: problem deleting ValidatorEntry from index "+
+						"PrefixValidatorByStatusAndStakeAmount",
+				)
+			}
+		}
+
+		// Set ValidatorEntry key in PrefixValidatorByStatusAndStakeAmount. The value should be nil.
+		// We parse the ValidatorPKID from the key for this index.
+		key = DBKeyForValidatorByStatusAndStakeAmount(validatorEntry)
+		if err := DBSetWithTxn(txn, snap, key, nil, eventManager); err != nil {
+			return errors.Wrapf(
+				err, "DBUpdateValidatorWithTxn: problem storing ValidatorEntry in index PrefixValidatorByStatusAndStakeAmount",
+			)
+		}
 	}
 
 	return nil
@@ -2231,7 +2279,8 @@ func (bav *UtxoView) _deleteValidatorEntryMappings(validatorEntry *ValidatorEntr
 }
 
 func (bav *UtxoView) _flushValidatorEntriesToDbWithTxn(txn *badger.Txn, blockHeight uint64) error {
-	// Delete all entries in the ValidatorMapKeyToValidatorEntry UtxoView map.
+	// Iterate through all the entries and either delete or update them depending on their
+	// isDeleted status.
 	for validatorMapKeyIter, validatorEntryIter := range bav.ValidatorPKIDToValidatorEntry {
 		// Make a copy of the iterators since we make references to them below.
 		validatorMapKey := validatorMapKeyIter
@@ -2247,28 +2296,17 @@ func (bav *UtxoView) _flushValidatorEntriesToDbWithTxn(txn *badger.Txn, blockHei
 			)
 		}
 
-		// Delete the existing mappings in the db for this ValidatorMapKey. They
-		// will be re-added if the corresponding entry in memory has isDeleted=false.
-		if err := DBDeleteValidatorWithTxn(txn, bav.Snapshot, &validatorMapKey, bav.EventManager, validatorEntry.isDeleted); err != nil {
-			return errors.Wrapf(err, "_flushValidatorEntriesToDbWithTxn: ")
-		}
-	}
-
-	// Set any !isDeleted ValidatorEntries in the ValidatorMapKeyToValidatorEntry UtxoView map.
-	for _, validatorEntryIter := range bav.ValidatorPKIDToValidatorEntry {
-		validatorEntry := *validatorEntryIter
+		// Delete entries if they have isDeleted=true
 		if validatorEntry.isDeleted {
-			// If ValidatorEntry.isDeleted then there's nothing to
-			// do because we already deleted the entry above.
+			if err := DBDeleteValidatorWithTxn(txn, bav.Snapshot, &validatorMapKey, bav.EventManager, validatorEntry.isDeleted); err != nil {
+				return errors.Wrapf(err, "_flushValidatorEntriesToDbWithTxn: ")
+			}
 		} else {
-			// If !ValidatorEntry.isDeleted then we put the
-			// corresponding mappings for it into the db.
-			if err := DBPutValidatorWithTxn(txn, bav.Snapshot, &validatorEntry, blockHeight, bav.EventManager); err != nil {
+			if err := DBUpdateValidatorWithTxn(txn, bav.Snapshot, &validatorEntry, blockHeight, bav.EventManager); err != nil {
 				return errors.Wrapf(err, "_flushValidatorEntriesToDbWithTxn: ")
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/lib/pos_snapshot_entries.go
+++ b/lib/pos_snapshot_entries.go
@@ -426,37 +426,26 @@ func (bav *UtxoView) _flushSnapshotValidatorSetToDbWithTxn(txn *badger.Txn, bloc
 				mapKey.SnapshotAtEpochNumber,
 			)
 		}
-		if err := DBDeleteSnapshotValidatorSetEntryWithTxn(
-			txn, bav.Snapshot, &mapKey.ValidatorPKID, mapKey.SnapshotAtEpochNumber, bav.EventManager, validatorEntry.isDeleted,
-		); err != nil {
-			return errors.Wrapf(
-				err,
-				"_flushSnapshotValidatorSetToDbWithTxn: problem deleting ValidatorEntry for EpochNumber %d: ",
-				mapKey.SnapshotAtEpochNumber,
-			)
-		}
-	}
-
-	// Put all !isDeleted SnapshotValidatorSet entry into the db from the UtxoView.
-	for mapKey, validatorEntry := range bav.SnapshotValidatorSet {
-		if validatorEntry == nil {
-			return fmt.Errorf(
-				"_flushSnapshotValidatorSetToDbWithTxn: found nil entry for EpochNumber %d, this should never happen",
-				mapKey.SnapshotAtEpochNumber,
-			)
-		}
 		if validatorEntry.isDeleted {
-			// Skip any deleted SnapshotValidatorSet.
-			continue
-		}
-		if err := DBPutSnapshotValidatorSetEntryWithTxn(
-			txn, bav.Snapshot, validatorEntry, mapKey.SnapshotAtEpochNumber, blockHeight, bav.EventManager,
-		); err != nil {
-			return errors.Wrapf(
-				err,
-				"_flushSnapshotValidatorSetToDbWithTxn: problem setting ValidatorEntry for EpochNumber %d: ",
-				mapKey.SnapshotAtEpochNumber,
-			)
+			if err := DBDeleteSnapshotValidatorSetEntryWithTxn(
+				txn, bav.Snapshot, &mapKey.ValidatorPKID, mapKey.SnapshotAtEpochNumber, bav.EventManager, validatorEntry.isDeleted,
+			); err != nil {
+				return errors.Wrapf(
+					err,
+					"_flushSnapshotValidatorSetToDbWithTxn: problem deleting ValidatorEntry for EpochNumber %d: ",
+					mapKey.SnapshotAtEpochNumber,
+				)
+			}
+		} else {
+			if err := DBUpdateSnapshotValidatorSetEntryWithTxn(
+				txn, bav.Snapshot, validatorEntry, mapKey.SnapshotAtEpochNumber, blockHeight, bav.EventManager,
+			); err != nil {
+				return errors.Wrapf(
+					err,
+					"_flushSnapshotValidatorSetToDbWithTxn: problem setting ValidatorEntry for EpochNumber %d: ",
+					mapKey.SnapshotAtEpochNumber,
+				)
+			}
 		}
 	}
 	return nil
@@ -559,7 +548,14 @@ func DBGetSnapshotValidatorSetByStakeAmount(
 	return validatorEntries, nil
 }
 
-func DBPutSnapshotValidatorSetEntryWithTxn(
+// In order to optimize the flush, we want to only write entries to the db that have changed.
+// On top of that, we add a further optimization to only update the
+// PrefixSnapshotValidatorSetByStakeAmount index if the stake amount has changed. Not doing this results
+// in a lot of writes to badger every epoch that eventually slow block processing to a crawl.
+// This is essentially a bug in badger when you repeatedly write to the same key, and we're
+// papering over it here in response to encountering the issue. In an ideal world, badger
+// would work as intended and this extra optimization wouldn't be necessary.
+func DBUpdateSnapshotValidatorSetEntryWithTxn(
 	txn *badger.Txn,
 	snap *Snapshot,
 	validatorEntry *ValidatorEntry,
@@ -569,7 +565,24 @@ func DBPutSnapshotValidatorSetEntryWithTxn(
 ) error {
 	if validatorEntry == nil {
 		// This should never happen but is a sanity check.
-		glog.Errorf("DBPutSnapshotValidatorSetEntryWithTxn: called with nil ValidatorEntry, this should never happen")
+		glog.Errorf("DBUpdateSnapshotValidatorSetEntryWithTxn: called with nil ValidatorEntry, this should never happen")
+		return nil
+	}
+
+	// Look up the existing entry
+	dbEntry, err := DBGetSnapshotValidatorSetEntryByPKIDWithTxn(
+		txn, snap, validatorEntry.ValidatorPKID, snapshotAtEpochNumber)
+	if err != nil {
+		return errors.Wrapf(
+			err, "DBUpdateSnapshotValidatorSetEntryWithTxn: problem retrieving ValidatorEntry for PKID %v: ",
+			validatorEntry.ValidatorPKID,
+		)
+	}
+	dbEntryBytes := EncodeToBytes(blockHeight, dbEntry)
+
+	entryToWriteBytes := EncodeToBytes(blockHeight, validatorEntry)
+	// If the entry in the db is the same as the entry we want to write, then no need to do anything.
+	if bytes.Equal(dbEntryBytes, entryToWriteBytes) {
 		return nil
 	}
 
@@ -578,19 +591,34 @@ func DBPutSnapshotValidatorSetEntryWithTxn(
 	if err := DBSetWithTxn(txn, snap, key, EncodeToBytes(blockHeight, validatorEntry), eventManager); err != nil {
 		return errors.Wrapf(
 			err,
-			"DBPutSnapshotValidatorSetEntryWithTxn: problem putting ValidatorEntry in the SnapshotValidatorByPKID index: ",
+			"DBUpdateSnapshotValidatorSetEntryWithTxn: problem putting ValidatorEntry in the SnapshotValidatorByPKID index: ",
 		)
 	}
 
-	// Put the ValidatorPKID in the SnapshotValidatorByStatusAndStakeAmount index.
-	key = DBKeyForSnapshotValidatorSetByStakeAmount(validatorEntry, snapshotAtEpochNumber)
-	if err := DBSetWithTxn(txn, snap, key, EncodeToBytes(blockHeight, validatorEntry.ValidatorPKID), eventManager); err != nil {
-		return errors.Wrapf(
-			err,
-			"DBPutSnapshotValidatorSetEntryWithTxn: problem putting ValidatorPKID in the SnapshotValidatorByStake index: ",
-		)
-	}
+	// Only update the PrefixSnapshotValidatorSetByStakeAmount index if the stake amount has changed.
+	if dbEntry == nil || dbEntry.TotalStakeAmountNanos.Cmp(validatorEntry.TotalStakeAmountNanos) != 0 {
+		// Delete the existing index value if it exists.
+		if dbEntry != nil {
+			key = DBKeyForSnapshotValidatorSetByStakeAmount(dbEntry, snapshotAtEpochNumber)
+			// Note we set isDeleted=false as a hint to the state syncer that we're about to
+			// update this value immediately after.
+			if err := DBDeleteWithTxn(txn, snap, key, eventManager, false); err != nil {
+				return errors.Wrapf(
+					err,
+					"DBUpdateSnapshotValidatorSetEntryWithTxn: problem deleting ValidatorPKID from the SnapshotValidatorByStake index: ",
+				)
+			}
+		}
 
+		// Put the ValidatorPKID in the SnapshotValidatorByStatusAndStakeAmount index.
+		key = DBKeyForSnapshotValidatorSetByStakeAmount(validatorEntry, snapshotAtEpochNumber)
+		if err := DBSetWithTxn(txn, snap, key, EncodeToBytes(blockHeight, validatorEntry.ValidatorPKID), eventManager); err != nil {
+			return errors.Wrapf(
+				err,
+				"DBUpdateSnapshotValidatorSetEntryWithTxn: problem putting ValidatorPKID in the SnapshotValidatorByStake index: ",
+			)
+		}
+	}
 	return nil
 }
 

--- a/lib/server.go
+++ b/lib/server.go
@@ -2336,8 +2336,10 @@ func (srv *Server) _handleBlockBundle(pp *Peer, bundle *MsgDeSoBlockBundle) {
 				pp)))
 
 			elapsed := time.Since(blockProcessingStartTime)
+			// Reset the blockProcessingStartTime so that each 1k blocks is timed individually
+			blockProcessingStartTime = time.Now()
 			if ii != 0 {
-				fmt.Printf("We are processing %v blocks per second\n", float64(ii)/(float64(elapsed)/1e9))
+				fmt.Printf("We are processing %v blocks per second\n", float64(1000)/(float64(elapsed)/1e9))
 			}
 		}
 	}


### PR DESCRIPTION
This change fully resolves a block syncing slowness issue encountered in the last phase of PoS testing.

    In order to optimize flushes for certain prefixes, we want to only write entries to the db that have changed.
    On top of that, we add a further optimization to only update related indexes if the stake amount or status has changed in the
    validator. Not doing this results in a lot of writes to badger
    every epoch that eventually slow block processing to a crawl. This is essentially a bug in
    badger when you repeatedly write to the same key, and we're papering over it here in response
    to encountering the issue. In an ideal world, badger would work as intended and this extra
    optimization wouldn't be necessary.
    
    Prefixes affected:
    * PrefixStakeByValidatorAndStaker
    * PrefixStakeByStakeAmount
    * PrefixValidatorByPKID
    * PrefixValidatorByStatusAndStakeAmount
    * PrefixSnapshotValidatorSetByPKID
    * PrefixSnapshotValidatorSetByStakeAmount
