### PR TITLE
Recompute fees in CreateAtomicTxnWrapper

### DIFF
--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4163,7 +4163,7 @@ func (bav *UtxoView) ConnectTransactionsFailSafe(
 	txns []*MsgDeSoTxn, txHashes []*BlockHash, blockHeight uint32, blockTimestampNanoSecs int64,
 	verifySignatures bool, ignoreUtxos bool, ignoreFailing bool) (
 	_combinedUtxoOps [][]*UtxoOperation, _totalInputs []uint64, _totalOutputs []uint64,
-	_fees []uint64, _successFlags []bool, _err error) {
+	_fees []uint64, _errorsFound []error, _err error) {
 
 	return bav._connectTransactionsFailSafe(txns, txHashes, blockHeight, blockTimestampNanoSecs, verifySignatures,
 		ignoreUtxos, ignoreFailing, 0)
@@ -4177,7 +4177,7 @@ func (bav *UtxoView) ConnectTransactionsFailSafeWithLimit(
 	txns []*MsgDeSoTxn, txHashes []*BlockHash, blockHeight uint32, blockTimestampNanoSecs int64,
 	verifySignatures bool, ignoreUtxos bool, ignoreFailing bool, transactionConnectLimit uint64) (
 	_combinedUtxoOps [][]*UtxoOperation, _totalInputs []uint64, _totalOutputs []uint64,
-	_fees []uint64, _successFlags []bool, _err error) {
+	_fees []uint64, _errorsFound []error, _err error) {
 
 	return bav._connectTransactionsFailSafe(txns, txHashes, blockHeight, blockTimestampNanoSecs, verifySignatures,
 		ignoreUtxos, ignoreFailing, transactionConnectLimit)
@@ -4187,21 +4187,21 @@ func (bav *UtxoView) _connectTransactionsFailSafe(
 	txns []*MsgDeSoTxn, txHashes []*BlockHash, blockHeight uint32, blockTimestampNanoSecs int64,
 	verifySignatures bool, ignoreUtxos bool, ignoreFailing bool, transactionConnectLimit uint64) (
 	_combinedUtxoOps [][]*UtxoOperation, _totalInputs []uint64, _totalOutputs []uint64,
-	_fees []uint64, _successFlags []bool, _err error) {
+	_fees []uint64, _errorsFound []error, _err error) {
 
 	var combinedUtxoOps [][]*UtxoOperation
 	var totalInputs []uint64
 	var totalOutputs []uint64
 	var fees []uint64
-	var successFlags []bool
+	var errorsFound []error
 	var totalConnectedTxns uint64
 
-	updateValues := func(utxoOps []*UtxoOperation, totalInput uint64, totalOutput uint64, fee uint64, success bool) {
+	updateValues := func(utxoOps []*UtxoOperation, totalInput uint64, totalOutput uint64, fee uint64, errFound error) {
 		combinedUtxoOps = append(combinedUtxoOps, utxoOps)
 		totalInputs = append(totalInputs, totalInput)
 		totalOutputs = append(totalOutputs, totalOutput)
 		fees = append(fees, fee)
-		successFlags = append(successFlags, success)
+		errorsFound = append(errorsFound, errFound)
 	}
 
 	// Connect the transactions in the order they are given.
@@ -4233,7 +4233,7 @@ func (bav *UtxoView) _connectTransactionsFailSafe(
 			return nil, nil, nil, nil, nil,
 				errors.Wrapf(err, "_connectTransactionsFailSafe: Problem connecting txn %d", ii)
 		}
-		updateValues(utxoOpsForTxn, totalInput, totalOutput, fee, true)
+		updateValues(utxoOpsForTxn, totalInput, totalOutput, fee, nil)
 
 		// If the transactionConnectLimit was set to 0, we will try to connect all the provided transactions.
 		if transactionConnectLimit == 0 {
@@ -4248,7 +4248,7 @@ func (bav *UtxoView) _connectTransactionsFailSafe(
 		}
 	}
 
-	return combinedUtxoOps, totalInputs, totalOutputs, fees, successFlags, nil
+	return combinedUtxoOps, totalInputs, totalOutputs, fees, errorsFound, nil
 }
 
 func (bav *UtxoView) ValidateTransactionNonce(txn *MsgDeSoTxn, blockHeight uint64) error {

--- a/lib/block_view.go
+++ b/lib/block_view.go
@@ -4219,7 +4219,7 @@ func (bav *UtxoView) _connectTransactionsFailSafe(
 		if err != nil && ignoreFailing {
 			// If ignoreFailing was set, we mark the transaction as failing and continue.
 			glog.V(2).Infof("_connectTransactionsFailSafe: Ignoring failing txn %d: %v", ii, err)
-			updateValues(nil, 0, 0, 0, false)
+			updateValues(nil, 0, 0, 0, err)
 			continue
 		} else if err != nil {
 			return nil, nil, nil, nil, nil,

--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -1732,6 +1732,13 @@ func CheckTransactionSanity(txn *MsgDeSoTxn, blockHeight uint32, params *DeSoPar
 		existingInputs[*txin] = true
 	}
 
+	// Make sure the transaction has a signature.
+	if txn.TxnMeta.GetTxnType() != TxnTypeBitcoinExchange &&
+		txn.TxnMeta.GetTxnType() != TxnTypeAtomicTxnsWrapper &&
+		txn.Signature.Sign == nil {
+		return RuleErrorTransactionHasNoSignature
+	}
+
 	return nil
 }
 

--- a/lib/legacy_mempool.go
+++ b/lib/legacy_mempool.go
@@ -2458,7 +2458,7 @@ func EstimateMaxTxnFeeV1(txn *MsgDeSoTxn, minFeeRateNanosPerKB uint64) uint64 {
 	for feeAmountNanos == 0 || feeAmountNanos != prevFeeAmountNanos {
 		prevFeeAmountNanos = feeAmountNanos
 		feeAmountNanos = _computeMaxTxV1Fee(txn, minFeeRateNanosPerKB)
-		txn.TxnFeeNanos = feeAmountNanos
+		UpdateTxnFee(txn, feeAmountNanos)
 	}
 	return feeAmountNanos
 }

--- a/lib/legacy_mempool.go
+++ b/lib/legacy_mempool.go
@@ -2651,9 +2651,9 @@ func (mp *DeSoMempool) BlockUntilReadOnlyViewRegenerated() {
 // WaitForTxnValidation is a blocking call that waits for a transaction to be validated.
 // The legacy mempool doesn't validate transactions, so this function always returns true
 // after BlockUntilReadOnlyViewRegenerated is called.
-func (mp *DeSoMempool) WaitForTxnValidation(_ *BlockHash) bool {
+func (mp *DeSoMempool) WaitForTxnValidation(_ *BlockHash) error {
 	mp.BlockUntilReadOnlyViewRegenerated()
-	return true
+	return nil
 }
 
 func (mp *DeSoMempool) StartMempoolDBDumper() {

--- a/lib/pos_mempool.go
+++ b/lib/pos_mempool.go
@@ -529,7 +529,11 @@ func (mp *PosMempool) AddTransaction(mtxn *MempoolTransaction) error {
 
 	// Acquire the mempool lock for all operations related to adding the transaction
 	// TODO: Do we need to wrap all of our validation logic in a write-lock? We should revisit
-	// this later and try to pull as much as we can out of the critical section here.
+	// this later and try to pull as much as we can out of the critical section here. The reason
+	// we added this lock is because checkTransactionSanity was calling ValidateTransactionNonce
+	// on the readOnly view, which was causing a modification of the view's PKID map at the same
+	// time as another thread was reading from it. This lock solves the issue but may not be the
+	// most optimal.
 	mp.Lock()
 	defer mp.Unlock()
 

--- a/lib/pos_mempool.go
+++ b/lib/pos_mempool.go
@@ -729,6 +729,9 @@ func (mp *PosMempool) addTransactionNoLock(txn *MempoolTx, persistToDb bool) err
 		}
 		// Only add the wrapper transaction to the transaction register.
 		if err := mp.txnRegister.AddTransaction(txn); err != nil {
+			// If we failed to add the transaction to the txn register, we need to remove the inner txns'
+			// nonces from the nonce tracker.
+			mp.removeNonces(innerTxnsWithNoncesAdded)
 			return errors.Wrapf(err, "PosMempool.addTransactionNoLock: Problem adding txn to register")
 		}
 		// Emit a persist event only for the wrapper transaction.

--- a/lib/server.go
+++ b/lib/server.go
@@ -274,9 +274,10 @@ func (srv *Server) BroadcastTransaction(txn *MsgDeSoTxn) ([]*MsgDeSoTxn, error) 
 
 	// At this point, we know the transaction has been run through the mempool.
 	// Now wait for an update of the ReadOnlyUtxoView so we don't break anything.
-	isValidated := srv.GetMempool().WaitForTxnValidation(txnHash)
-	if !isValidated {
-		return nil, fmt.Errorf("BroadcastTransaction: Transaction %v was not validated", txnHash)
+	validationErr := srv.GetMempool().WaitForTxnValidation(txnHash)
+	if validationErr != nil {
+		return nil, fmt.Errorf("BroadcastTransaction: Transaction %v "+
+			"was not validated due to error: %v", txnHash, validationErr)
 	}
 
 	return mempoolTxs, nil


### PR DESCRIPTION
This PR has kinda increased in scope but I'm adding a description below that addresses all of the changes in this PR from feature/proof-of-stake. I'm also going to change the comparison branch to feature/proof-of-stake to make it a full review.

* From @diamondhands:

  * Improve the error returned when we reject a txn from the mempool

    * This required adding a cache of the errors we produce when validating txns and using that to return the error upon request
  * Improve CreateAtomicTxnWrapper to add automatic fee computation

    * CreateAtomicTxnWrapper will now compute the exact fee required for each inner txn and update the fee on that txn if it's lower than what was computed
    * CreateAtomicTxnWrapper now computes the TOTAL fee required to submit the atomic txn, including the wrapper txn, and intelligently adds the extra required to the first inner txn in the list
  * Fix a bug in computeFeeRecursive to properly assess the nonce. Without this, we were over-estimating the fee significantly.
  * Fix a bug in computeFeeRecursive to properly assess signature sizes in atomic txns. Without this, we were significantly under-estimating txn size.
  * Introduce an UpdateTxnFee function that bundles in a special-case of updating the fee on a DAOCoinLimitOrder txn

    * Replaced all raw fee adjustments with a call to this function in core and backend
  * Mark DAOCoinLimitOrder.FeeNanos as deprecated. We don't need it after balance model, but if we don't set it to exactly the txn.TxnFeeNanos we get an error.
  * Add some error-checking in pos mempool that was missing
* From @lazynina:

  * Proper sanity-checking of atomic txns
  * Add nonce handling for atomic txns

    * Although note there is still a TODO to add a synthetic nonce for atomic txns so that you can replace them by fee. This isn't time-sensitive so we're punting on it. Added a TODO in addTransactionNoLock for it.

