### PR TITLE
Relax check transaction signature checking

### DIFF
--- a/lib/blockchain.go
+++ b/lib/blockchain.go
@@ -1865,13 +1865,6 @@ func CheckTransactionSanity(txn *MsgDeSoTxn, blockHeight uint32, params *DeSoPar
 		existingInputs[*txin] = true
 	}
 
-	// Make sure the transaction has a signature.
-	if txn.TxnMeta.GetTxnType() != TxnTypeBitcoinExchange &&
-		txn.TxnMeta.GetTxnType() != TxnTypeAtomicTxnsWrapper &&
-		txn.Signature.Sign == nil {
-		return RuleErrorTransactionHasNoSignature
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This check causes CreateDAOCoinLimitOrder to fail during transaction construction because it calls simulateSubmitTransaction, which calls getDAOCoinLimitOrderSimulatedExecutionResult, which then hits this. Easiest to just remove it. The signatures are always checked later anyway.