### PR TITLE
Fix checksum computation at the snapshot height

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -2443,7 +2443,7 @@ func (srv *Server) _handleBlockBundle(pp *Peer, bundle *MsgDeSoBlockBundle) {
 		// gracefully fail.
 		srv._handleBlock(pp, blk, ii == len(bundle.Blocks)-1 /*isLastBlock*/)
 		numLogBlocks := 100
-		if srv.params.IsPoWBlockHeight(blk.Header.Height) ||
+		if srv.params.IsPoSBlockHeight(blk.Header.Height) ||
 			srv.params.NetworkType == NetworkType_TESTNET {
 			numLogBlocks = 1000
 		}


### PR DESCRIPTION
Making snapshot computation synchronous broke the checksum computation at the snapshot height because computing the snapshot was still asynchronous. This change waits for the checksum to be fully updated before it updates the snapshot to the new checksum value.

I also made the blocks requested+sent higher for testnet, which makes syncing much faster.